### PR TITLE
bumped versions of setup-solana and setup-anchor

### DIFF
--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -104,10 +104,10 @@ jobs:
       failed_projects: ${{ steps.set-failed.outputs.failed_projects }}
     steps:
       - uses: actions/checkout@v4
-      - uses: heyAyushh/setup-anchor@v4.2
+      - uses: heyAyushh/setup-anchor@v4.4
         with:
           anchor-version: 0.30.1
-          solana-cli-version: 1.18.17
+          solana-cli-version: stable
           node-version: 20.x
           use-avm: false
       - name: Display Versions and Install pnpm

--- a/.github/workflows/solana-native.yml
+++ b/.github/workflows/solana-native.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true
-      - uses: heyAyushh/setup-solana@v5.4
+      - uses: heyAyushh/setup-solana@v5.5
         with:
           solana-cli-version: ${{ matrix.solana-version }}
-      - run: solana block
+      - run: solana -V
         shell: bash
       - name: Install pnpm
         run: |


### PR DESCRIPTION
Native action were earlier found failing.
This PR acknowledges that, builds anchor with solana stable, 

and setup-solana uses heyAyushh/setup-solana instead of metadao one for getting version tags like "stable".