### PR TITLE
fix: Steel CLI requires solana keypair at root

### DIFF
--- a/.github/workflows/steel.yml
+++ b/.github/workflows/steel.yml
@@ -150,13 +150,6 @@ jobs:
         with:
           path: ~/.cargo/bin/steel
           key: ${{ runner.os }}-steel-cli
-      - name: Display Versions and Install pnpm
-        run: |
-          solana -V
-          solana-keygen new --no-bip39-passphrase
-          rustc -V
-          anchor -V
-          npm i -g pnpm
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -271,6 +264,7 @@ jobs:
           source build_and_test.sh
           solana -V
           rustc -V
+          solana-keygen new --no-bip39-passphrase
           process_projects "stable"
           sccache --show-stats
       - name: Setup Solana 1.18.17
@@ -285,6 +279,7 @@ jobs:
           source build_and_test.sh
           solana -V
           rustc -V
+          solana-keygen new --no-bip39-passphrase
           process_projects "1.18.17"
           sccache --show-stats
 

--- a/.github/workflows/steel.yml
+++ b/.github/workflows/steel.yml
@@ -279,7 +279,7 @@ jobs:
           source build_and_test.sh
           solana -V
           rustc -V
-          solana-keygen new --no-bip39-passphrase
+          solana-keygen new --no-bip39-passphrase --force
           process_projects "1.18.17"
           sccache --show-stats
 

--- a/.github/workflows/steel.yml
+++ b/.github/workflows/steel.yml
@@ -150,6 +150,13 @@ jobs:
         with:
           path: ~/.cargo/bin/steel
           key: ${{ runner.os }}-steel-cli
+      - name: Display Versions and Install pnpm
+        run: |
+          solana -V
+          solana-keygen new --no-bip39-passphrase
+          rustc -V
+          anchor -V
+          npm i -g pnpm
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/steel.yml
+++ b/.github/workflows/steel.yml
@@ -253,7 +253,7 @@ jobs:
           chmod +x build_and_test.sh
 
       - name: Setup Solana stable
-        uses: heyAyushh/setup-solana@v5.4
+        uses: heyAyushh/setup-solana@v5.5
         with:
           solana-cli-version: stable
       - name: Build and Test with Stable
@@ -268,7 +268,7 @@ jobs:
           process_projects "stable"
           sccache --show-stats
       - name: Setup Solana 1.18.17
-        uses: heyAyushh/setup-solana@v5.4
+        uses: heyAyushh/setup-solana@v5.5
         with:
           solana-cli-version: 1.18.17
       - name: Build and Test with 1.18.17

--- a/basics/hello-solana/steel/Cargo.toml
+++ b/basics/hello-solana/steel/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["solana"]
 [workspace.dependencies]
 bytemuck = "1.14"
 num_enum = "0.7"
-solana-program = "1.18"
-steel = "2.0"
+solana-program = "2.0.13"
+steel = "1.3"
 thiserror = "1.0"
 solana-sdk = "1.18"

--- a/basics/hello-solana/steel/Cargo.toml
+++ b/basics/hello-solana/steel/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["solana"]
 [workspace.dependencies]
 bytemuck = "1.14"
 num_enum = "0.7"
-solana-program = "2.0.13"
-steel = "2.1"
+solana-program = "=2.0.13"
+steel = "=2.1.1"
 thiserror = "1.0"
 solana-sdk = "1.18"

--- a/basics/hello-solana/steel/Cargo.toml
+++ b/basics/hello-solana/steel/Cargo.toml
@@ -16,6 +16,6 @@ keywords = ["solana"]
 bytemuck = "1.14"
 num_enum = "0.7"
 solana-program = "2.0.13"
-steel = "1.3"
+steel = "2.1"
 thiserror = "1.0"
 solana-sdk = "1.18"

--- a/basics/hello-solana/steel/program/Cargo.toml
+++ b/basics/hello-solana/steel/program/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-solana-program = "2.0.13"
-steel = "2.1"
+solana-program = "=2.0.13"
+steel = "=2.1.1"

--- a/basics/hello-solana/steel/program/Cargo.toml
+++ b/basics/hello-solana/steel/program/Cargo.toml
@@ -8,4 +8,4 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 solana-program = "2.0.13"
-steel = "1.3.0"
+steel = "2.1"

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,8 @@
       "suspicious": {
         "noExplicitAny": "off",
         "noAssignInExpressions": "warn",
-        "noExportsInTest": "warn"
+        "noExportsInTest": "warn",
+        "noShadowRestrictedNames": "off"
       },
       "style": {
         "noParameterAssign": "warn",


### PR DESCRIPTION
- create solana keygen at root for steel CLI
- pin hello solana steel crate versions
- add biome exception for importing `String` in poseidon workflows