### PR TITLE
Update transfer hook examples

### DIFF
--- a/tokens/token-2022/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
@@ -20,5 +20,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 anchor-lang = { version = "0.31.1", features = ["interface-instructions"] }
 anchor-spl = "0.31.1"
 solana-program = "2.1.15"
-spl-tlv-account-resolution = "0.10.0"
-spl-transfer-hook-interface = "0.10.0"
+spl-tlv-account-resolution = "0.9.0"
+spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-2022/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/account-data-as-seed/anchor/programs/transfer-hook/Cargo.toml
@@ -20,5 +20,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 anchor-lang = { version = "0.31.1", features = ["interface-instructions"] }
 anchor-spl = "0.31.1"
 solana-program = "2.1.15"
-spl-tlv-account-resolution = "0.6.0"
-spl-transfer-hook-interface = "0.6.0"
+spl-tlv-account-resolution = "0.10.0"
+spl-transfer-hook-interface = "0.10.0"

--- a/tokens/token-2022/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
@@ -20,5 +20,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 anchor-lang = { version = "0.31.1", features = ["interface-instructions"] }
 anchor-spl = "0.31.1"
 solana-program = "2.1.15"
-spl-tlv-account-resolution = "0.10.0"
-spl-transfer-hook-interface = "0.10.0"
+spl-tlv-account-resolution = "0.9.0"
+spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-2022/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/counter/anchor/programs/transfer-hook/Cargo.toml
@@ -20,5 +20,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 anchor-lang = { version = "0.31.1", features = ["interface-instructions"] }
 anchor-spl = "0.31.1"
 solana-program = "2.1.15"
-spl-tlv-account-resolution = "0.6.3"
-spl-transfer-hook-interface = "0.6.3"
+spl-tlv-account-resolution = "0.10.0"
+spl-transfer-hook-interface = "0.10.0"

--- a/tokens/token-2022/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
@@ -19,5 +19,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = { version = "0.31.1", features = ["interface-instructions"] }
 anchor-spl = "0.31.1"
-spl-tlv-account-resolution = "0.10.0"
-spl-transfer-hook-interface = "0.10.0"
+spl-tlv-account-resolution = "0.9.0"
+spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-2022/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/hello-world/anchor/programs/transfer-hook/Cargo.toml
@@ -19,5 +19,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = { version = "0.31.1", features = ["interface-instructions"] }
 anchor-spl = "0.31.1"
-spl-tlv-account-resolution = "0.6.3"
-spl-transfer-hook-interface = "0.6.3"
+spl-tlv-account-resolution = "0.10.0"
+spl-transfer-hook-interface = "0.10.0"

--- a/tokens/token-2022/transfer-hook/hello-world/anchor/tests/transfer-hook.ts
+++ b/tokens/token-2022/transfer-hook/hello-world/anchor/tests/transfer-hook.ts
@@ -9,6 +9,7 @@ import {
   getAssociatedTokenAddressSync,
 } from '@solana/spl-token';
 import { Keypair, SendTransactionError, Transaction, sendAndConfirmTransaction } from '@solana/web3.js';
+import { BN } from 'bn.js';
 import { expect } from 'chai';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -130,7 +131,7 @@ describe('transfer-hook', () => {
 
   it('Try call transfer hook without transfer', async () => {
     const transferHookIx = await program.methods
-      .transferHook(new anchor.BN(1))
+      .transferHook(new BN(1))
       .accounts({
         sourceToken: sourceTokenAccount,
         mint: mint.publicKey,

--- a/tokens/token-2022/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
@@ -19,5 +19,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = {version = "0.31.1", features = ["interface-instructions"]}
 anchor-spl = "0.31.1"
-spl-tlv-account-resolution = "0.10.0"
-spl-transfer-hook-interface = "0.10.0"
+spl-tlv-account-resolution = "0.9.0"
+spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-2022/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/transfer-cost/anchor/programs/transfer-hook/Cargo.toml
@@ -19,5 +19,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = {version = "0.31.1", features = ["interface-instructions"]}
 anchor-spl = "0.31.1"
-spl-tlv-account-resolution = "0.6.3"
-spl-transfer-hook-interface = "0.6.3"
+spl-tlv-account-resolution = "0.10.0"
+spl-transfer-hook-interface = "0.10.0"

--- a/tokens/token-2022/transfer-hook/transfer-switch/anchor/programs/transfer-switch/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/transfer-switch/anchor/programs/transfer-switch/Cargo.toml
@@ -19,5 +19,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = {version="0.31.1", features=["init-if-needed", "interface-instructions"]}
 anchor-spl = {version="0.31.1"}
-spl-tlv-account-resolution = "0.10.0"
-spl-transfer-hook-interface = "0.10.0"
+spl-tlv-account-resolution = "0.9.0"
+spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-2022/transfer-hook/transfer-switch/anchor/programs/transfer-switch/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/transfer-switch/anchor/programs/transfer-switch/Cargo.toml
@@ -19,5 +19,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = {version="0.31.1", features=["init-if-needed", "interface-instructions"]}
 anchor-spl = {version="0.31.1"}
-spl-tlv-account-resolution = "0.6.3"
-spl-transfer-hook-interface = "0.6.3"
+spl-tlv-account-resolution = "0.10.0"
+spl-transfer-hook-interface = "0.10.0"

--- a/tokens/token-2022/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
@@ -19,5 +19,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = {version = "0.31.0", features = ["interface-instructions", "init-if-needed"]}
 anchor-spl = "0.31.0"
-spl-tlv-account-resolution = "0.10.0"
-spl-transfer-hook-interface = "0.10.0"
+spl-tlv-account-resolution = "0.9.0"
+spl-transfer-hook-interface = "0.9.0"

--- a/tokens/token-2022/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/whitelist/anchor/programs/transfer-hook/Cargo.toml
@@ -19,5 +19,5 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 [dependencies]
 anchor-lang = {version = "0.31.0", features = ["interface-instructions", "init-if-needed"]}
 anchor-spl = "0.31.0"
-spl-tlv-account-resolution = "0.6.3"
-spl-transfer-hook-interface = "0.6.3"
+spl-tlv-account-resolution = "0.10.0"
+spl-transfer-hook-interface = "0.10.0"

--- a/tokens/token-2022/transfer-hook/whitelist/anchor/readme.md
+++ b/tokens/token-2022/transfer-hook/whitelist/anchor/readme.md
@@ -1,0 +1,2 @@
+Note that the white list example is not really scalable for big projects since you at some points will run out of account space. 
+A better approach will be to use external PDAs that store the whitelist instead. 


### PR DESCRIPTION
Transferhooks examples were running into this error: 
https://solana.stackexchange.com/questions/22662/cloning-and-building-example-programs-in-anchor/22753#22753

This is fixed in the new spl-transfer-hook-interface version 