### PR TITLE
docs(counter): fix native readme for the bankrun/pnpm flow

### DIFF
--- a/basics/counter/native/README.md
+++ b/basics/counter/native/README.md
@@ -2,13 +2,18 @@
 
 This example program is written in Solana using only the Solana toolsuite.
 
-## Setup
+## Build and test
 
-1. Build the program with `cargo build-sbf`
-2. Run tests + local validator with `yarn test`
+```shell
+pnpm build-and-test
+```
 
-## Debugging
+This builds the program with `cargo build-sbf` and runs the tests against an
+in-process `solana-bankrun` runtime — no local validator required.
 
-1. Start test validator with `yarn start-validator`
-2. Start listening to program logs with `solana config set -ul && solana logs`
-3. Run tests with `yarn run-tests`
+## Deploy
+
+```shell
+pnpm build
+pnpm deploy
+```


### PR DESCRIPTION
## Summary
- `basics/counter/native/README.md` still documented the old, removed workflow (`yarn test`, `yarn start-validator`, `yarn run-tests` + a local `solana-test-validator`). Those scripts no longer exist.
- The example now builds with `cargo build-sbf` and tests **in-process via solana-bankrun** (no validator). Update the README to the current `pnpm build-and-test` / `pnpm build` / `pnpm deploy` scripts.

## Test Plan
- Docs-only change; no code affected.
- Verified the documented commands match `basics/counter/native/package.json` scripts, and that `counter/native` builds + tests green in CI (bankrun, loads from `./tests/fixtures`).

The underlying bug in the issue (the `./target/deploy/counter_solana_native.so` not-found error from the old yarn/validator setup) was already resolved by the rewrite to solana-bankrun; this finishes it by fixing the stale docs.

Closes #67