### PR TITLE
Fix inverted contribute/refund time gates in token-fundraiser (anchor)

### DIFF
--- a/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/contribute.rs
+++ b/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/contribute.rs
@@ -68,10 +68,11 @@ impl<'info> Contribute<'info> {
             FundraiserError::ContributionTooBig
         );
 
-        // Check if the fundraising duration has been reached
+        // Contributions are only accepted while the campaign is still open,
+        // i.e. before `duration` days have elapsed since it started.
         let current_time = Clock::get()?.unix_timestamp;
         require!(
-            self.fundraiser.duration <= ((current_time - self.fundraiser.time_started) / SECONDS_TO_DAYS) as u16,
+            (((current_time - self.fundraiser.time_started) / SECONDS_TO_DAYS) as u16) < self.fundraiser.duration,
             crate::FundraiserError::FundraiserEnded
         );
 

--- a/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/refund.rs
+++ b/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/refund.rs
@@ -54,11 +54,12 @@ pub struct Refund<'info> {
 impl<'info> Refund<'info> {
     pub fn refund(&mut self) -> Result<()> {
 
-        // Check if the fundraising duration has been reached
+        // Refunds are only allowed once the campaign has ended, i.e. after
+        // `duration` days have elapsed since it started.
         let current_time = Clock::get()?.unix_timestamp;
- 
+
         require!(
-            self.fundraiser.duration >= ((current_time - self.fundraiser.time_started) / SECONDS_TO_DAYS) as u16,
+            (((current_time - self.fundraiser.time_started) / SECONDS_TO_DAYS) as u16) >= self.fundraiser.duration,
             crate::FundraiserError::FundraiserNotEnded
         );
 

--- a/tokens/token-fundraiser/anchor/tests/bankrun.test.ts
+++ b/tokens/token-fundraiser/anchor/tests/bankrun.test.ts
@@ -12,7 +12,7 @@ import {
 import { PublicKey } from "@solana/web3.js";
 import { BankrunProvider } from "anchor-bankrun";
 import BN from "bn.js";
-import { startAnchor } from "solana-bankrun";
+import { Clock, startAnchor } from "solana-bankrun";
 import IDL from "../target/idl/fundraiser.json";
 import type { Fundraiser } from "../target/types/fundraiser";
 
@@ -225,10 +225,72 @@ describe("fundraiser bankrun", async () => {
         })
         .rpc()
         .then(confirm);
-    } catch {
+    } catch (error) {
       rejected = true;
+      assert.ok(
+        String(error).includes("FundraiserNotEnded"),
+        `expected a FundraiserNotEnded error, got: ${error}`,
+      );
     }
 
     assert.ok(rejected, "refund should be rejected while the campaign is still open");
+  });
+
+  it("Refunds the contributor after the campaign ends", async () => {
+    const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
+
+    // Advance the clock past the 5-day campaign window so refunds are allowed.
+    const clock = await context.banksClient.getClock();
+    context.setClock(
+      new Clock(
+        clock.slot,
+        clock.epochStartTimestamp,
+        clock.epoch,
+        clock.leaderScheduleEpoch,
+        clock.unixTimestamp + BigInt(6 * 24 * 60 * 60),
+      ),
+    );
+
+    const before = BigInt(
+      (await provider.connection.getTokenAccountBalance(contributorATA)).value.amount,
+    );
+
+    const tx = await program.methods
+      .refund()
+      .accountsPartial({
+        contributor: provider.publicKey,
+        maker: maker.publicKey,
+        mintToRaise: mint,
+        fundraiser,
+        contributorAccount: contributor,
+        contributorAta: contributorATA,
+        vault,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: anchor.web3.SystemProgram.programId,
+      })
+      .rpc()
+      .then(confirm);
+
+    console.log("\nRefunded contributions", tx);
+
+    // The 2_000_000 contributed is returned to the contributor.
+    const after = BigInt(
+      (await provider.connection.getTokenAccountBalance(contributorATA)).value.amount,
+    );
+    assert.equal(after - before, BigInt(2_000_000), "contributor should be refunded their contribution");
+
+    // The vault is emptied and the contributor account is closed.
+    assert.equal(
+      (await provider.connection.getTokenAccountBalance(vault)).value.amount,
+      "0",
+      "vault should be empty after the refund",
+    );
+    let closed = false;
+    try {
+      await program.account.contributor.fetch(contributor);
+    } catch {
+      closed = true;
+    }
+    assert.ok(closed, "contributor account should be closed after the refund");
   });
 });

--- a/tokens/token-fundraiser/anchor/tests/bankrun.test.ts
+++ b/tokens/token-fundraiser/anchor/tests/bankrun.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { describe, it } from "node:test";
 import * as anchor from "@anchor-lang/core";
 import {
@@ -82,7 +83,7 @@ describe("fundraiser bankrun", async () => {
     const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
     const tx = await program.methods
-      .initialize(new BN(30000000), 0)
+      .initialize(new BN(30000000), 5)
       .accountsPartial({
         maker: maker.publicKey,
         fundraiser,
@@ -200,30 +201,34 @@ describe("fundraiser bankrun", async () => {
     }
   });
 
-  it("Refund Contributions", async () => {
+  it("Refund is rejected while the campaign is still open", async () => {
+    // The campaign was created with a 5-day duration and has only just started,
+    // so a refund must be rejected until the campaign has ended. (A successful
+    // refund requires advancing the validator clock past `duration`, e.g. with
+    // bankrun's `setClock`.)
     const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
-    const contributorAccount = await program.account.contributor.fetch(contributor);
-    console.log("\nContributor balance", contributorAccount.amount.toString());
+    let rejected = false;
+    try {
+      await program.methods
+        .refund()
+        .accountsPartial({
+          contributor: provider.publicKey,
+          maker: maker.publicKey,
+          mintToRaise: mint,
+          fundraiser,
+          contributorAccount: contributor,
+          contributorAta: contributorATA,
+          vault,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          systemProgram: anchor.web3.SystemProgram.programId,
+        })
+        .rpc()
+        .then(confirm);
+    } catch {
+      rejected = true;
+    }
 
-    const tx = await program.methods
-      .refund()
-      .accountsPartial({
-        contributor: provider.publicKey,
-        maker: maker.publicKey,
-        mintToRaise: mint,
-        fundraiser,
-        contributorAccount: contributor,
-        contributorAta: contributorATA,
-        vault,
-        tokenProgram: TOKEN_PROGRAM_ID,
-        systemProgram: anchor.web3.SystemProgram.programId,
-      })
-      .rpc()
-      .then(confirm);
-
-    console.log("\nRefunded contributions", tx);
-    console.log("Your transaction signature", tx);
-    console.log("Vault balance", (await provider.connection.getTokenAccountBalance(vault)).value.amount);
+    assert.ok(rejected, "refund should be rejected while the campaign is still open");
   });
 });

--- a/tokens/token-fundraiser/anchor/tests/bankrun.test.ts
+++ b/tokens/token-fundraiser/anchor/tests/bankrun.test.ts
@@ -222,10 +222,9 @@ describe("fundraiser bankrun", async () => {
   });
 
   it("Refund is rejected while the campaign is still open", async () => {
-    // The campaign was created with a 5-day duration and has only just started,
-    // so a refund must be rejected until the campaign has ended. (A successful
-    // refund requires advancing the validator clock past `duration`, e.g. with
-    // bankrun's `setClock`.)
+    // One day into the 5-day campaign, so a refund must be rejected until it
+    // ends. (The successful-refund case advances the clock past `duration`.)
+    await setElapsedDays(1);
     const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
     let rejected = false;

--- a/tokens/token-fundraiser/anchor/tests/bankrun.test.ts
+++ b/tokens/token-fundraiser/anchor/tests/bankrun.test.ts
@@ -52,6 +52,23 @@ describe("fundraiser bankrun", async () => {
     return signature;
   };
 
+  // Pin the bankrun clock to a deterministic point in the campaign so the
+  // day-based time gates are exercised regardless of the runtime's default
+  // clock behaviour: `days` days after the fundraiser's recorded start time.
+  const setElapsedDays = async (days: number) => {
+    const state = await program.account.fundraiser.fetch(fundraiser);
+    const clock = await context.banksClient.getClock();
+    context.setClock(
+      new Clock(
+        clock.slot,
+        clock.epochStartTimestamp,
+        clock.epoch,
+        clock.leaderScheduleEpoch,
+        BigInt(state.timeStarted.toString()) + BigInt(days * 24 * 60 * 60),
+      ),
+    );
+  };
+
   it("Test Preparation", async () => {
     const airdrop = await provider.connection
       .requestAirdrop(maker.publicKey, 1 * anchor.web3.LAMPORTS_PER_SOL)
@@ -99,6 +116,9 @@ describe("fundraiser bankrun", async () => {
 
     console.log("\nInitialized fundraiser Account");
     console.log("Your transaction signature", tx);
+
+    // Place "now" one day into the 5-day campaign so contributions are open.
+    await setElapsedDays(1);
   });
 
   it("Contribute to Fundraiser", async () => {
@@ -227,10 +247,7 @@ describe("fundraiser bankrun", async () => {
         .then(confirm);
     } catch (error) {
       rejected = true;
-      assert.ok(
-        String(error).includes("FundraiserNotEnded"),
-        `expected a FundraiserNotEnded error, got: ${error}`,
-      );
+      assert.ok(String(error).includes("FundraiserNotEnded"), `expected a FundraiserNotEnded error, got: ${error}`);
     }
 
     assert.ok(rejected, "refund should be rejected while the campaign is still open");
@@ -240,20 +257,9 @@ describe("fundraiser bankrun", async () => {
     const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
     // Advance the clock past the 5-day campaign window so refunds are allowed.
-    const clock = await context.banksClient.getClock();
-    context.setClock(
-      new Clock(
-        clock.slot,
-        clock.epochStartTimestamp,
-        clock.epoch,
-        clock.leaderScheduleEpoch,
-        clock.unixTimestamp + BigInt(6 * 24 * 60 * 60),
-      ),
-    );
+    await setElapsedDays(6);
 
-    const before = BigInt(
-      (await provider.connection.getTokenAccountBalance(contributorATA)).value.amount,
-    );
+    const before = BigInt((await provider.connection.getTokenAccountBalance(contributorATA)).value.amount);
 
     const tx = await program.methods
       .refund()
@@ -274,9 +280,7 @@ describe("fundraiser bankrun", async () => {
     console.log("\nRefunded contributions", tx);
 
     // The 2_000_000 contributed is returned to the contributor.
-    const after = BigInt(
-      (await provider.connection.getTokenAccountBalance(contributorATA)).value.amount,
-    );
+    const after = BigInt((await provider.connection.getTokenAccountBalance(contributorATA)).value.amount);
     assert.equal(after - before, BigInt(2_000_000), "contributor should be refunded their contribution");
 
     // The vault is emptied and the contributor account is closed.


### PR DESCRIPTION
## Summary

The `token-fundraiser` (Anchor) example gates `contribute` and `refund` on the campaign window with **inverted** comparisons:

- `contribute` only accepted contributions **after** the campaign window had closed (`require!(duration <= elapsed_days, FundraiserEnded)`).
- `refund` only allowed refunds **while** the campaign was still open (`require!(duration >= elapsed_days, FundraiserNotEnded)`).

So for any real (non-zero duration) fundraiser, contributions are rejected for the entire campaign and only allowed once it's over, while refunds are allowed during the campaign and blocked afterwards — the opposite of the intended behaviour.

The bug is invisible today because the test uses `duration = 0`, where both inverted conditions happen to evaluate correctly (`0 <= 0` and `0 >= 0`).

## Fix

- `contribute` now rejects once `elapsed_days >= duration` (campaign ended) → contributions accepted **while the campaign is open**.
- `refund` now rejects while `elapsed_days < duration` (campaign still open) → refunds allowed **only after it ends**.

(The cast is parenthesised — `(… as u16) < duration` — to avoid Rust parsing `as u16 <` as a generic.)

## Tests

The tests now create a non-zero (open) campaign so contributions are valid, and assert that a refund is rejected while the campaign is still open. A successful refund requires advancing the validator clock past `duration` (e.g. via bankrun's `setClock`).

## Verification

The Anchor program compiles (`cargo build-sbf`). The identical semantic fix was applied to the Pinocchio port of this example in #613, where the corrected behaviour was verified end-to-end on a local `solana-test-validator` (contributions accepted while open, rejected after the campaign ends; refunds rejected while open).
