### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dev-jodee


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` assigning @dev-jodee as default owner for all paths
- Enables automatic review assignment on future PRs

## Test Plan
- After merge, GitHub's CODEOWNERS validation at Settings → Code owners (or any new PR) should show @dev-jodee auto-requested for review