### PR TITLE
fix: repair three CI-broken native programs

### DIFF
--- a/basics/cross-program-invocation/native/programs/hand/Cargo.toml
+++ b/basics/cross-program-invocation/native/programs/hand/Cargo.toml
@@ -10,9 +10,9 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-borsh = "1.5.7"
-borsh-derive = "1.5.7"
-solana-program = "3.0"
+borsh = "1.6.1"
+borsh-derive = "1.6.1"
+solana-program = "4.0"
 cross-program-invocatio-native-lever = { path = "../lever", features = ["cpi"] }
 
 [lib]

--- a/basics/cross-program-invocation/native/programs/lever/Cargo.toml
+++ b/basics/cross-program-invocation/native/programs/lever/Cargo.toml
@@ -10,9 +10,9 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-borsh = "1.5.7"
-borsh-derive = "1.5.7"
-solana-program = "3.0"
+borsh = "1.6.1"
+borsh-derive = "1.6.1"
+solana-program = "4.0"
 solana-system-interface = {version = "2.0.0", features = ["bincode"]}
 
 [lib]

--- a/basics/favorites/native/tests/test.ts
+++ b/basics/favorites/native/tests/test.ts
@@ -135,12 +135,13 @@ describe("Favorites Solana Native", () => {
     tx.recentBlockhash = blockhash;
     tx.sign(payer);
     tx.recentBlockhash = blockhash;
+    let threw = false;
     try {
       await client.processTransaction(tx);
-      assert(false, "Expected transaction to fail with wrong PDA seeds");
     } catch (_err) {
-      assert(true);
+      threw = true;
     }
+    assert(threw, "Expected transaction to fail with wrong PDA seeds");
   });
 
   test("Get the favorite pda and cross-check the data", async () => {

--- a/basics/favorites/native/tests/test.ts
+++ b/basics/favorites/native/tests/test.ts
@@ -6,7 +6,6 @@ import {
   Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
-import { BN } from "bn.js";
 import * as borsh from "borsh";
 import { assert, expect } from "chai";
 import { describe, test } from "mocha";
@@ -103,15 +102,15 @@ describe("Favorites Solana Native", () => {
 
     console.log("Deserialized data:", favoritesData);
 
-    expect(new BN(favoritesData.number as Buffer, "le").toNumber()).to.equal(favData.number);
+    expect(Number(favoritesData.number)).to.equal(favData.number);
     expect(favoritesData.color).to.equal(favData.color);
     expect(favoritesData.hobbies).to.deep.equal(favData.hobbies);
   });
 
   test("Check if the test fails if the pda seeds aren't same", async () => {
-    // We put the wrong seeds knowingly to see if the test fails because of checks
-    const favoritesPda = PublicKey.findProgramAddressSync(
-      [Buffer.from("favorite"), payer.publicKey.toBuffer()],
+    // Derive a PDA using WRONG seeds so the program's on-chain seed check rejects it
+    const wrongPda = PublicKey.findProgramAddressSync(
+      [Buffer.from("wrong_seed"), payer.publicKey.toBuffer()],
       programId,
     )[0];
     const favData = {
@@ -124,7 +123,7 @@ describe("Favorites Solana Native", () => {
     const ix = new TransactionInstruction({
       keys: [
         { pubkey: payer.publicKey, isSigner: true, isWritable: true },
-        { pubkey: favoritesPda, isSigner: false, isWritable: true },
+        { pubkey: wrongPda, isSigner: false, isWritable: true },
         { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       ],
       programId,
@@ -138,7 +137,7 @@ describe("Favorites Solana Native", () => {
     tx.recentBlockhash = blockhash;
     try {
       await client.processTransaction(tx);
-      console.error("Expected the test to fail");
+      assert(false, "Expected transaction to fail with wrong PDA seeds");
     } catch (_err) {
       assert(true);
     }

--- a/basics/realloc/native/package.json
+++ b/basics/realloc/native/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
+    "borsh": "^2.0.0",
     "fs": "^0.0.1-security"
   },
   "devDependencies": {

--- a/basics/realloc/native/pnpm-lock.yaml
+++ b/basics/realloc/native/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@solana/web3.js':
         specifier: ^1.98.4
         version: 1.98.4(bufferutil@4.0.9)(typescript@4.9.5)(utf-8-validate@5.0.10)
+      borsh:
+        specifier: ^2.0.0
+        version: 2.0.0
       fs:
         specifier: ^0.0.1-security
         version: 0.0.1-security
@@ -164,6 +167,9 @@ packages:
 
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
+
+  borsh@2.0.0:
+    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -531,14 +537,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   solana-bankrun-linux-x64-musl@0.3.1:
     resolution: {integrity: sha512-6r8i0NuXg3CGURql8ISMIUqhE7Hx/O7MlIworK4oN08jYrP0CXdLeB/hywNn7Z8d1NXrox/NpYUgvRm2yIzAsQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   solana-bankrun@0.3.1:
     resolution: {integrity: sha512-inRwON7fBU5lPC36HdEqPeDg15FXJYcf77+o0iz9amvkUMJepcwnRwEfTNyMVpVYdgjTOBW5vg+596/3fi1kGA==}
@@ -833,6 +837,8 @@ snapshots:
       bn.js: 5.2.2
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
+
+  borsh@2.0.0: {}
 
   brace-expansion@1.1.11:
     dependencies:

--- a/basics/realloc/native/ts/instructions/create.ts
+++ b/basics/realloc/native/ts/instructions/create.ts
@@ -3,51 +3,15 @@ import { type PublicKey, SystemProgram, TransactionInstruction } from "@solana/w
 import * as borsh from "borsh";
 import { ReallocInstruction } from "./instruction";
 
-export class Create {
-  instruction: ReallocInstruction;
-  name: string;
-  house_number: number;
-  street: string;
-  city: string;
-
-  constructor(props: {
-    instruction: ReallocInstruction;
-    name: string;
-    house_number: number;
-    street: string;
-    city: string;
-  }) {
-    this.instruction = props.instruction;
-    this.name = props.name;
-    this.house_number = props.house_number;
-    this.street = props.street;
-    this.city = props.city;
-  }
-
-  toBuffer() {
-    return Buffer.from(borsh.serialize(CreateSchema, this));
-  }
-
-  static fromBuffer(buffer: Buffer) {
-    return borsh.deserialize(CreateSchema, Create, buffer);
-  }
-}
-
-export const CreateSchema = new Map([
-  [
-    Create,
-    {
-      kind: "struct",
-      fields: [
-        ["instruction", "u8"],
-        ["name", "string"],
-        ["house_number", "u8"],
-        ["street", "string"],
-        ["city", "string"],
-      ],
-    },
-  ],
-]);
+const CreateSchema = {
+  struct: {
+    instruction: "u8",
+    name: "string",
+    house_number: "u8",
+    street: "string",
+    city: "string",
+  },
+} as const;
 
 export function createCreateInstruction(
   target: PublicKey,
@@ -58,23 +22,23 @@ export function createCreateInstruction(
   street: string,
   city: string,
 ): TransactionInstruction {
-  const instructionObject = new Create({
-    instruction: ReallocInstruction.Create,
-    name,
-    house_number,
-    street,
-    city,
-  });
+  const data = Buffer.from(
+    borsh.serialize(CreateSchema, {
+      instruction: ReallocInstruction.Create,
+      name,
+      house_number,
+      street,
+      city,
+    }),
+  );
 
-  const ix = new TransactionInstruction({
+  return new TransactionInstruction({
     keys: [
-      { pubkey: target, isSigner: false, isWritable: true },
+      { pubkey: target, isSigner: true, isWritable: true },
       { pubkey: payer, isSigner: true, isWritable: true },
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
     ],
-    programId: programId,
-    data: instructionObject.toBuffer(),
+    programId,
+    data,
   });
-
-  return ix;
 }

--- a/basics/realloc/native/ts/instructions/reallocate.ts
+++ b/basics/realloc/native/ts/instructions/reallocate.ts
@@ -3,43 +3,13 @@ import { type PublicKey, SystemProgram, TransactionInstruction } from "@solana/w
 import * as borsh from "borsh";
 import { ReallocInstruction } from "./instruction";
 
-export class ReallocateWithoutZeroInit {
-  instruction: ReallocInstruction;
-  state: string;
-  zip: number;
-
-  constructor(props: {
-    instruction: ReallocInstruction;
-    state: string;
-    zip: number;
-  }) {
-    this.instruction = props.instruction;
-    this.state = props.state;
-    this.zip = props.zip;
-  }
-
-  toBuffer() {
-    return Buffer.from(borsh.serialize(ReallocateWithoutZeroInitSchema, this));
-  }
-
-  static fromBuffer(buffer: Buffer) {
-    return borsh.deserialize(ReallocateWithoutZeroInitSchema, ReallocateWithoutZeroInit, buffer);
-  }
-}
-
-export const ReallocateWithoutZeroInitSchema = new Map([
-  [
-    ReallocateWithoutZeroInit,
-    {
-      kind: "struct",
-      fields: [
-        ["instruction", "u8"],
-        ["state", "string"],
-        ["zip", "u32"],
-      ],
-    },
-  ],
-]);
+const ReallocateWithoutZeroInitSchema = {
+  struct: {
+    instruction: "u8",
+    state: "string",
+    zip: "u32",
+  },
+} as const;
 
 export function createReallocateWithoutZeroInitInstruction(
   target: PublicKey,
@@ -48,70 +18,34 @@ export function createReallocateWithoutZeroInitInstruction(
   state: string,
   zip: number,
 ): TransactionInstruction {
-  const instructionObject = new ReallocateWithoutZeroInit({
-    instruction: ReallocInstruction.ReallocateWithoutZeroInit,
-    state,
-    zip,
-  });
+  const data = Buffer.from(
+    borsh.serialize(ReallocateWithoutZeroInitSchema, {
+      instruction: ReallocInstruction.ReallocateWithoutZeroInit,
+      state,
+      zip,
+    }),
+  );
 
-  const ix = new TransactionInstruction({
+  return new TransactionInstruction({
     keys: [
       { pubkey: target, isSigner: false, isWritable: true },
       { pubkey: payer, isSigner: true, isWritable: true },
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
     ],
-    programId: programId,
-    data: instructionObject.toBuffer(),
+    programId,
+    data,
   });
-
-  return ix;
 }
 
-export class ReallocateZeroInit {
-  instruction: ReallocInstruction;
-  name: string;
-  position: string;
-  company: string;
-  years_employed: number;
-
-  constructor(props: {
-    instruction: ReallocInstruction;
-    name: string;
-    position: string;
-    company: string;
-    years_employed: number;
-  }) {
-    this.instruction = props.instruction;
-    this.name = props.name;
-    this.position = props.position;
-    this.company = props.company;
-    this.years_employed = props.years_employed;
-  }
-
-  toBuffer() {
-    return Buffer.from(borsh.serialize(ReallocateZeroInitSchema, this));
-  }
-
-  static fromBuffer(buffer: Buffer) {
-    return borsh.deserialize(ReallocateZeroInitSchema, ReallocateZeroInit, buffer);
-  }
-}
-
-export const ReallocateZeroInitSchema = new Map([
-  [
-    ReallocateZeroInit,
-    {
-      kind: "struct",
-      fields: [
-        ["instruction", "u8"],
-        ["name", "string"],
-        ["position", "string"],
-        ["company", "string"],
-        ["years_employed", "u8"],
-      ],
-    },
-  ],
-]);
+const ReallocateZeroInitSchema = {
+  struct: {
+    instruction: "u8",
+    name: "string",
+    position: "string",
+    company: "string",
+    years_employed: "u8",
+  },
+} as const;
 
 export function createReallocateZeroInitInstruction(
   target: PublicKey,
@@ -122,19 +56,19 @@ export function createReallocateZeroInitInstruction(
   company: string,
   years_employed: number,
 ): TransactionInstruction {
-  const instructionObject = new ReallocateZeroInit({
-    instruction: ReallocInstruction.ReallocateZeroInit,
-    name,
-    position,
-    company,
-    years_employed,
-  });
+  const data = Buffer.from(
+    borsh.serialize(ReallocateZeroInitSchema, {
+      instruction: ReallocInstruction.ReallocateZeroInit,
+      name,
+      position,
+      company,
+      years_employed,
+    }),
+  );
 
-  const ix = new TransactionInstruction({
+  return new TransactionInstruction({
     keys: [{ pubkey: target, isSigner: false, isWritable: true }],
-    programId: programId,
-    data: instructionObject.toBuffer(),
+    programId,
+    data,
   });
-
-  return ix;
 }

--- a/basics/realloc/native/ts/state/address-info.ts
+++ b/basics/realloc/native/ts/state/address-info.ts
@@ -1,6 +1,15 @@
 import { Buffer } from "node:buffer";
 import * as borsh from "borsh";
 
+export const AddressInfoSchema = {
+  struct: {
+    name: "string",
+    house_number: "u8",
+    street: "string",
+    city: "string",
+  },
+} as const;
+
 export class AddressInfo {
   name: string;
   house_number: number;
@@ -19,30 +28,11 @@ export class AddressInfo {
     this.city = props.city;
   }
 
-  toBase58() {
-    return borsh.serialize(AddressInfoSchema, this).toString();
-  }
-
   toBuffer() {
     return Buffer.from(borsh.serialize(AddressInfoSchema, this));
   }
 
-  static fromBuffer(buffer: Buffer) {
-    return borsh.deserialize(AddressInfoSchema, AddressInfo, buffer);
+  static fromBuffer(buffer: Buffer): AddressInfo {
+    return borsh.deserialize(AddressInfoSchema, buffer) as AddressInfo;
   }
 }
-
-export const AddressInfoSchema = new Map([
-  [
-    AddressInfo,
-    {
-      kind: "struct",
-      fields: [
-        ["name", "string"],
-        ["house_number", "u8"],
-        ["street", "string"],
-        ["city", "string"],
-      ],
-    },
-  ],
-]);

--- a/basics/realloc/native/ts/state/enhanced-address-info.ts
+++ b/basics/realloc/native/ts/state/enhanced-address-info.ts
@@ -1,6 +1,17 @@
 import { Buffer } from "node:buffer";
 import * as borsh from "borsh";
 
+export const EnhancedAddressInfoSchema = {
+  struct: {
+    name: "string",
+    house_number: "u8",
+    street: "string",
+    city: "string",
+    state: "string",
+    zip: "u32",
+  },
+} as const;
+
 export class EnhancedAddressInfo {
   name: string;
   house_number: number;
@@ -25,32 +36,11 @@ export class EnhancedAddressInfo {
     this.zip = props.zip;
   }
 
-  toBase58() {
-    return borsh.serialize(EnhancedAddressInfoSchema, this).toString();
-  }
-
   toBuffer() {
     return Buffer.from(borsh.serialize(EnhancedAddressInfoSchema, this));
   }
 
-  static fromBuffer(buffer: Buffer) {
-    return borsh.deserialize(EnhancedAddressInfoSchema, EnhancedAddressInfo, buffer);
+  static fromBuffer(buffer: Buffer): EnhancedAddressInfo {
+    return borsh.deserialize(EnhancedAddressInfoSchema, buffer) as EnhancedAddressInfo;
   }
 }
-
-export const EnhancedAddressInfoSchema = new Map([
-  [
-    EnhancedAddressInfo,
-    {
-      kind: "struct",
-      fields: [
-        ["name", "string"],
-        ["house_number", "u8"],
-        ["street", "string"],
-        ["city", "string"],
-        ["state", "string"],
-        ["zip", "u32"],
-      ],
-    },
-  ],
-]);

--- a/basics/realloc/native/ts/state/work-info.ts
+++ b/basics/realloc/native/ts/state/work-info.ts
@@ -1,6 +1,15 @@
 import { Buffer } from "node:buffer";
 import * as borsh from "borsh";
 
+export const WorkInfoSchema = {
+  struct: {
+    name: "string",
+    position: "string",
+    company: "string",
+    years_employed: "u8",
+  },
+} as const;
+
 export class WorkInfo {
   name: string;
   position: string;
@@ -19,30 +28,11 @@ export class WorkInfo {
     this.years_employed = props.years_employed;
   }
 
-  toBase58() {
-    return borsh.serialize(WorkInfoSchema, this).toString();
-  }
-
   toBuffer() {
     return Buffer.from(borsh.serialize(WorkInfoSchema, this));
   }
 
-  static fromBuffer(buffer: Buffer) {
-    return borsh.deserialize(WorkInfoSchema, WorkInfo, buffer);
+  static fromBuffer(buffer: Buffer): WorkInfo {
+    return borsh.deserialize(WorkInfoSchema, buffer) as WorkInfo;
   }
 }
-
-export const WorkInfoSchema = new Map([
-  [
-    WorkInfo,
-    {
-      kind: "struct",
-      fields: [
-        ["name", "string"],
-        ["position", "string"],
-        ["company", "string"],
-        ["years_employed", "u8"],
-      ],
-    },
-  ],
-]);

--- a/basics/realloc/native/ts/util/util.ts
+++ b/basics/realloc/native/ts/util/util.ts
@@ -1,5 +1,6 @@
+import { readFileSync } from "node:fs";
 import { Keypair } from "@solana/web3.js";
 
 export function createKeypairFromFile(path: string): Keypair {
-  return Keypair.fromSecretKey(Buffer.from(JSON.parse(require("node:fs").readFileSync(path, "utf-8"))));
+  return Keypair.fromSecretKey(Buffer.from(JSON.parse(readFileSync(path, "utf-8"))));
 }


### PR DESCRIPTION
## Summary

- **cross-program-invocation/native**: bump `borsh 1.5.7→1.6.1`, `borsh-derive 1.5.7→1.6.1`, `solana-program 3.0→4.0` in hand and lever `Cargo.toml` — the isolated workspace was pinning stale versions that conflict with the rest of the workspace
- **realloc/native**: migrate `ts/` from borsh v1 Map-based API to borsh v2 `{struct:...}` schema; add missing `"borsh": "^2.0.0"` direct dependency (it was absent from `package.json`, making the import unresolvable); fix `isSigner: false→true` on target account in `createCreateInstruction` (was causing `MissingRequiredSignature` on the `create_account` CPI); fix CJS `require("node:fs")` → ESM import in `util.ts`
- **favorites/native**: fix `u64` assertion (`new BN(number as Buffer, "le")` → `Number(favoritesData.number)` since borsh v2 deserializes u64 as bigint); fix "wrong seeds" test which was deriving the *correct* PDA and expecting failure — changed to use a genuinely wrong seed so the on-chain check actually rejects it

## Test plan

- [ ] CI runs `pnpm build-and-test` for `cross-program-invocation/native` — Rust build with updated deps passes, TS test passes
- [ ] CI runs `pnpm build-and-test` for `realloc/native` — Rust build passes, borsh v2 serialization works at runtime, `create_account` CPI succeeds with correct signer flag
- [ ] `favorites/native` test logic fixes visible in diff; full CI validation pending `.ghaignore` removal once bankrun/SBF compatibility is confirmed on current platform-tools