### PR TITLE
fix(world-cup): pin codama to stop IDL drift

### DIFF
--- a/games/world-cup/pinocchio/Cargo.toml
+++ b/games/world-cup/pinocchio/Cargo.toml
@@ -25,7 +25,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [workspace.dependencies]
-codama = "0.9.2"
+codama = "=0.9.3"
 const-crypto = "0.3"
 pinocchio = { version = "0.11.1", features = ["cpi", "copy"] }
 pinocchio-system = "0.6.1"

--- a/games/world-cup/pinocchio/idl/world_cup.json
+++ b/games/world-cup/pinocchio/idl/world_cup.json
@@ -318,6 +318,7 @@
         }
       }
     ],
+    "constants": [],
     "definedTypes": [
       {
         "kind": "definedTypeNode",
@@ -1795,5 +1796,5 @@
     "version": "0.1.0"
   },
   "standard": "codama",
-  "version": "1.0.0"
+  "version": "1.6.0"
 }


### PR DESCRIPTION
## Summary
- The scheduled `Just` workflow always failed on `games/world-cup/pinocchio` at the `check-generated` step.
- Root cause: `codama = "0.9.2"` (caret) floated to `0.9.3`, whose IDL output differs from the committed `idl/world_cup.json` (adds `"constants": []`, bumps spec version `1.0.0` → `1.6.0`). No lockfile is committed for this sub-project, so CI resolved fresh every run → deterministic drift → failed every scheduled run.
- Pin `codama = "=0.9.3"` so IDL generation is deterministic.
- Regenerate and commit `idl/world_cup.json` to match.

## Test Plan
- `just generate-idl` twice produces zero diff against the committed IDL.
- `git diff --quiet -- idl clients/typescript/src/generated clients/rust/src/generated` is clean → `check-generated` passes.

## Notes
- Generated client dirs (`clients/*/src/generated`) are gitignored, so the `cargo-fmt not installed` warning in the CI log is cosmetic and does not affect `check-generated`.