### PR TITLE
ci: vendor setup-anchor with version parse fix

### DIFF
--- a/.github/actions/setup-anchor/LICENSE
+++ b/.github/actions/setup-anchor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 The Meta-DAO
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.github/actions/setup-anchor/action.yml
+++ b/.github/actions/setup-anchor/action.yml
@@ -1,0 +1,143 @@
+# Vendored from heyAyushh/setup-anchor@v4.999 (0dfcdd2), patched so the version
+# check parses only the `anchor-cli` line: newer avm's anchor proxy prints extra
+# Solana install output on `anchor --version`, and the multi-line value broke
+# $GITHUB_OUTPUT. Upstream fix pending: https://github.com/heyAyushh/setup-anchor
+name: 'Setup Anchor'
+description: 'Install Anchor, Solana CLI tools, and Node.js.'
+branding:
+  icon: anchor
+  color: blue
+inputs:
+  node-version:
+    description: 'Version of node.js to use'
+    required: false
+    default: 'lts/*'
+  solana-cli-version:
+    description: 'Version of Solana CLI to use'
+    required: false
+    default: 'stable'
+  anchor-version:
+    description: 'Version of Anchor to use'
+    required: false
+    default: '0.31.1'
+  use-avm:
+    description: 'Use Anchor Version Manager (AVM) to install Anchor'
+    required: false
+    default: "true"
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+    
+    - name: Output Node Version
+      id: node_v
+      shell: bash
+      run: |
+        echo "node_v=$(node -v)" >> $GITHUB_OUTPUT
+        echo "Using Node version: $(node -v)"
+    
+    - name: Setup Solana
+      uses: heyAyushh/setup-solana@v5.9
+      with:
+        solana-cli-version: ${{ inputs.solana-cli-version }}
+    
+    - name: Verify Solana installation
+      shell: bash
+      run: |
+        if ! command -v solana &> /dev/null; then
+          echo "ERROR: Solana CLI installation failed"
+          exit 1
+        fi
+        echo "Solana CLI version: $(solana --version)"
+        solana_version=$(echo $(solana --version) | awk '{print $2}')
+        echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
+
+    - name: Generate cache key
+      id: cache-key
+      shell: bash
+      run: |
+        echo "key=${{ runner.os }}-anchor-v${{ inputs.anchor-version }}-solana-v$SOLANA_VERSION" >> $GITHUB_OUTPUT
+
+    - name: Cache Anchor and Cargo
+      id: cache-anchor
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/avm
+          ~/.cargo/bin/anchor
+          ~/.avm
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ steps.cache-key.outputs.key }}
+
+    - name: Check for existing anchor installation
+      id: check-anchor
+      shell: bash
+      run: |
+        if command -v anchor &> /dev/null; then
+          installed_version=$(anchor --version | awk '/^anchor-cli / {v=$2} END {print v}')
+          echo "anchor_exists=true" >> $GITHUB_OUTPUT
+          echo "installed_version=$installed_version" >> $GITHUB_OUTPUT
+          echo "Found existing Anchor installation: $installed_version"
+        else
+          echo "anchor_exists=false" >> $GITHUB_OUTPUT
+          echo "No existing Anchor installation found"
+        fi
+
+    - name: Clean existing Anchor installation if version mismatch
+      if: steps.check-anchor.outputs.anchor_exists == 'true' && steps.check-anchor.outputs.installed_version != inputs.anchor-version
+      shell: bash
+      run: |
+        echo "Removing existing Anchor version to install requested version"
+        rm -rf ~/.cargo/bin/anchor
+        rm -rf ~/.avm
+
+    - name: Install Anchor with AVM
+      if: (steps.cache-anchor.outputs.cache-hit != 'true') || (steps.check-anchor.outputs.anchor_exists != 'true')
+      shell: bash
+      run: |
+        echo "Installing Anchor v${{ inputs.anchor-version }} via AVM..."
+        set -e
+        if ! command -v avm &> /dev/null; then
+           echo "Installing AVM..."
+           cargo install --git https://github.com/coral-xyz/anchor avm --force
+        fi
+        avm --version
+        avm install ${{ inputs.anchor-version }}
+        avm use ${{ inputs.anchor-version }}
+
+        if ! command -v anchor &> /dev/null; then
+          echo "ERROR: AVM installation failed, falling back to direct cargo install"
+          cargo install --git https://github.com/coral-xyz/anchor --tag v${{ inputs.anchor-version }} anchor-cli --force
+          if ! command -v anchor &> /dev/null; then
+            echo "ERROR: Cargo installation failed."
+            exit 1
+          fi
+        else
+          echo "AVM installation successful: $(anchor --version)"
+          exit 0
+        fi
+
+    - name: Verify Anchor and Rust installation
+      shell: bash
+      run: |
+        if ! command -v anchor &> /dev/null; then
+          echo "ERROR: Anchor installation verification failed"
+          exit 1
+        fi
+
+        anchor_version=$(anchor --version)
+        echo "Anchor installed successfully: $anchor_version"
+
+        # Verify version matches requested version
+        if [[ ! "$anchor_version" == *"${{ inputs.anchor-version }}"* ]]; then
+          echo "WARNING: Installed version ($anchor_version) may not match requested version (${{ inputs.anchor-version }})"
+        fi
+        
+        rust_version=$(rustc --version | awk '{print $2}')
+        echo "Rust version: $rust_version"

--- a/.github/actions/setup-anchor/action.yml
+++ b/.github/actions/setup-anchor/action.yml
@@ -1,3 +1,4 @@
+# Vendored from https://github.com/heyAyushh/setup-anchor @v4.999 (MIT, see LICENSE)
 name: 'Setup Anchor'
 description: 'Install Anchor, Solana CLI tools, and Node.js.'
 branding:

--- a/.github/actions/setup-anchor/action.yml
+++ b/.github/actions/setup-anchor/action.yml
@@ -1,7 +1,3 @@
-# Vendored from heyAyushh/setup-anchor@v4.999 (0dfcdd2), patched so the version
-# check parses only the `anchor-cli` line: newer avm's anchor proxy prints extra
-# Solana install output on `anchor --version`, and the multi-line value broke
-# $GITHUB_OUTPUT. Upstream fix pending: https://github.com/heyAyushh/setup-anchor
 name: 'Setup Anchor'
 description: 'Install Anchor, Solana CLI tools, and Node.js.'
 branding:

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v4
-      - uses: heyAyushh/setup-anchor@v4.999
+      - uses: ./.github/actions/setup-anchor
         with:
           anchor-version: 1.0.2
           solana-cli-version: stable


### PR DESCRIPTION
## Summary
- Anchor CI on main has been red since 2026-07-13: every `build-and-test-group-*` job dies in `heyAyushh/setup-anchor@v4.999` with `Invalid format '1.0.2'` when writing to `$GITHUB_OUTPUT`.
- Root cause: newer avm (cached since ~July 13) ships an `anchor` proxy that auto-activates the mapped Solana CLI (anchor 1.0.2 → solana 3.1.10 per avm's `anchor-solana-map.toml`) on every invocation. With solana 4.1.2 active, `anchor --version` re-installs solana 3.1.10 each run and emits extra stdout before the `anchor-cli 1.0.2` line. The action's `awk '{print $2}'` captures a multi-line value, which the runner rejects.
- Vendors the action at v4.999 (0dfcdd2) into `.github/actions/setup-anchor` with a one-line fix: parse only the `anchor-cli` line (`awk '/^anchor-cli / {v=$2} END {print v}'`), and points `anchor.yml` at the local copy.
- Can be reverted to the upstream tag once the same fix lands there.

## Test Plan
- This PR modifies `.github/workflows/anchor.yml`, which triggers the full Anchor matrix over all projects — the previously failing warm-cache path runs here directly.