### PR TITLE
ci: fix matrix stride, pin actions, add timeouts

### DIFF
--- a/.github/actions/setup-anchor/action.yml
+++ b/.github/actions/setup-anchor/action.yml
@@ -37,7 +37,7 @@ runs:
         echo "Using Node version: $(node -v)"
     
     - name: Setup Solana
-      uses: heyAyushh/setup-solana@v5.9
+      uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
       with:
         solana-cli-version: ${{ inputs.solana-cli-version }}
     

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -11,6 +11,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   MAX_JOBS: 64
   MIN_PROJECTS_PER_JOB: 4
@@ -25,15 +32,18 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       changed_projects: ${{ steps.analyze.outputs.changed_projects }}
       total_projects: ${{ steps.analyze.outputs.total_projects }}
       matrix: ${{ steps.matrix.outputs.matrix }}
+      projects_per_job: ${{ steps.matrix.outputs.projects_per_job }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         if: github.event_name == 'pull_request'
         with:
@@ -88,6 +98,7 @@ jobs:
           # Generate matrix based on number of projects
           if [ "$total_projects" -lt "$min_projects_for_matrix" ]; then
             echo "matrix=[0]" >> $GITHUB_OUTPUT
+            echo "projects_per_job=$total_projects" >> $GITHUB_OUTPUT
           else
             projects_per_job=$(( (total_projects + max_jobs - 1) / max_jobs ))
             projects_per_job=$(( projects_per_job > min_projects_per_job ? projects_per_job : min_projects_per_job ))
@@ -95,12 +106,14 @@ jobs:
 
             indices=$(seq 0 $(( num_jobs - 1 )))
             echo "matrix=[$(echo $indices | tr ' ' ',')]" >> $GITHUB_OUTPUT
+            echo "projects_per_job=$projects_per_job" >> $GITHUB_OUTPUT
           fi
 
   build-and-test:
     needs: changes
     if: needs.changes.outputs.total_projects != '0'
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +123,7 @@ jobs:
       failed_projects: ${{ steps.set-failed.outputs.failed_projects }}
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: ./.github/actions/setup-anchor
         with:
           anchor-version: 1.0.2
@@ -125,7 +138,7 @@ jobs:
       - name: Build and Test
         env:
           TOTAL_PROJECTS: ${{ needs.changes.outputs.total_projects }}
-          PROJECTS_PER_JOB: ${{ env.MIN_PROJECTS_PER_JOB }}
+          PROJECTS_PER_JOB: ${{ needs.changes.outputs.projects_per_job }}
         run: |
           function build_and_test() {
             local project=$1
@@ -214,6 +227,7 @@ jobs:
     needs: [changes, build-and-test]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Create job summary

--- a/.github/workflows/just.yml
+++ b/.github/workflows/just.yml
@@ -16,6 +16,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_NET_RETRY: "10"
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
@@ -25,7 +32,9 @@ env:
 jobs:
   discover:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       projects: ${{ steps.find.outputs.projects }}
@@ -78,6 +87,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.any == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -85,16 +95,16 @@ jobs:
     name: ${{ matrix.project }}
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
           node-version-file: ${{ matrix.project }}/.nvmrc
           check-latest: true
       - name: Install just
-        uses: extractions/setup-just@v4
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
       - name: Setup Solana
-        uses: heyAyushh/setup-solana@v5.9
+        uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:
           solana-cli-version: stable
       - name: Build and test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -25,10 +32,12 @@ jobs:
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           # Specific to dtolnay/rust-toolchain: Comma-separated string of additional components to install
           components: rustfmt
       - name: Enforce formatting
@@ -38,10 +47,12 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           components: clippy
       - name: Linting
         # Allow diverging_sub_expression: false positive from Anchor 1.0's #[program] macro expansion

--- a/.github/workflows/solana-asm.yml
+++ b/.github/workflows/solana-asm.yml
@@ -11,6 +11,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   MAX_JOBS: 64
   MIN_PROJECTS_PER_JOB: 4
@@ -23,15 +30,18 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       changed_projects: ${{ steps.analyze.outputs.changed_projects }}
       total_projects: ${{ steps.analyze.outputs.total_projects }}
       matrix: ${{ steps.matrix.outputs.matrix }}
+      projects_per_job: ${{ steps.matrix.outputs.projects_per_job }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         if: github.event_name == 'pull_request'
         with:
@@ -87,6 +97,7 @@ jobs:
 
           if [ "$total_projects" -lt "$min_projects_for_matrix" ]; then
             echo "matrix=[0]" >> $GITHUB_OUTPUT
+            echo "projects_per_job=$total_projects" >> $GITHUB_OUTPUT
           else
             projects_per_job=$(( (total_projects + max_jobs - 1) / max_jobs ))
             projects_per_job=$(( projects_per_job > min_projects_per_job ? projects_per_job : min_projects_per_job ))
@@ -94,12 +105,14 @@ jobs:
 
             indices=$(seq 0 $(( num_jobs - 1 )))
             echo "matrix=[$(echo $indices | tr ' ' ',')]" >> $GITHUB_OUTPUT
+            echo "projects_per_job=$projects_per_job" >> $GITHUB_OUTPUT
           fi
 
   build-and-test:
     needs: changes
     if: needs.changes.outputs.total_projects != '0'
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -161,8 +174,8 @@ jobs:
             local solana_version=$1
 
             readarray -t all_projects < <(echo '${{ needs.changes.outputs.changed_projects }}' | jq -r '.[]?')
-            start_index=$(( ${{ matrix.index }} * ${{ env.MIN_PROJECTS_PER_JOB }} ))
-            end_index=$(( start_index + ${{ env.MIN_PROJECTS_PER_JOB }} ))
+            start_index=$(( ${{ matrix.index }} * ${{ needs.changes.outputs.projects_per_job }} ))
+            end_index=$(( start_index + ${{ needs.changes.outputs.projects_per_job }} ))
             end_index=$(( end_index > ${{ needs.changes.outputs.total_projects }} ? ${{ needs.changes.outputs.total_projects }} : end_index ))
 
             echo "Projects to build and test in this job"
@@ -196,7 +209,7 @@ jobs:
           # example. Keep in sync with the pinned Solana version below.
           cargo install --git https://github.com/blueshift-gg/sbpf.git --rev 0223df0e7ba622d4956b4ecf3cf2397f6945b76b
       - name: Setup Solana Stable
-        uses: heyAyushh/setup-solana@v5.9
+        uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:
           # Pinned to 4.0.3, the last version the ASM examples passed on (paired
           # with sbpf v0.1.9 above). Floating "stable" moved to 4.1.1 in the same
@@ -214,7 +227,7 @@ jobs:
       # with heyAyushh/setup-solana — beta setup clears the stable install first.
       - name: Setup Solana Beta
         continue-on-error: true
-        uses: heyAyushh/setup-solana@v5.9
+        uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:
           solana-cli-version: beta
       - name: Build and Test with Beta
@@ -240,6 +253,7 @@ jobs:
     needs: [changes, build-and-test]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Create job summary

--- a/.github/workflows/solana-native.yml
+++ b/.github/workflows/solana-native.yml
@@ -11,6 +11,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   MAX_JOBS: 64
   MIN_PROJECTS_PER_JOB: 4
@@ -25,15 +32,18 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       changed_projects: ${{ steps.analyze.outputs.changed_projects }}
       total_projects: ${{ steps.analyze.outputs.total_projects }}
       matrix: ${{ steps.matrix.outputs.matrix }}
+      projects_per_job: ${{ steps.matrix.outputs.projects_per_job }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         if: github.event_name == 'pull_request'
         with:
@@ -89,6 +99,7 @@ jobs:
 
           if [ "$total_projects" -lt "$min_projects_for_matrix" ]; then
             echo "matrix=[0]" >> $GITHUB_OUTPUT
+            echo "projects_per_job=$total_projects" >> $GITHUB_OUTPUT
           else
             projects_per_job=$(( (total_projects + max_jobs - 1) / max_jobs ))
             projects_per_job=$(( projects_per_job > min_projects_per_job ? projects_per_job : min_projects_per_job ))
@@ -96,12 +107,14 @@ jobs:
 
             indices=$(seq 0 $(( num_jobs - 1 )))
             echo "matrix=[$(echo $indices | tr ' ' ',')]" >> $GITHUB_OUTPUT
+            echo "projects_per_job=$projects_per_job" >> $GITHUB_OUTPUT
           fi
 
   build-and-test:
     needs: changes
     if: needs.changes.outputs.total_projects != '0'
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +124,7 @@ jobs:
       failed_projects: ${{ steps.set-failed.outputs.failed_projects }}
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
@@ -172,8 +185,8 @@ jobs:
             local solana_version=$1
 
             readarray -t all_projects < <(echo '${{ needs.changes.outputs.changed_projects }}' | jq -r '.[]?')
-            start_index=$(( ${{ matrix.index }} * ${{ env.MIN_PROJECTS_PER_JOB }} ))
-            end_index=$(( start_index + ${{ env.MIN_PROJECTS_PER_JOB }} ))
+            start_index=$(( ${{ matrix.index }} * ${{ needs.changes.outputs.projects_per_job }} ))
+            end_index=$(( start_index + ${{ needs.changes.outputs.projects_per_job }} ))
             end_index=$(( end_index > ${{ needs.changes.outputs.total_projects }} ? ${{ needs.changes.outputs.total_projects }} : end_index ))
 
             echo "Projects to build and test in this job"
@@ -198,7 +211,7 @@ jobs:
           chmod +x build_and_test.sh
 
       - name: Setup Solana Stable
-        uses: heyAyushh/setup-solana@v5.9
+        uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:
           solana-cli-version: stable
       - name: Build and Test with Stable
@@ -212,7 +225,7 @@ jobs:
       # with heyAyushh/setup-solana — beta setup clears the stable install first.
       - name: Setup Solana Beta
         continue-on-error: true
-        uses: heyAyushh/setup-solana@v5.9
+        uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:
           solana-cli-version: beta
       - name: Build and Test with Beta
@@ -238,6 +251,7 @@ jobs:
     needs: [changes, build-and-test]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Create job summary

--- a/.github/workflows/solana-pinocchio.yml
+++ b/.github/workflows/solana-pinocchio.yml
@@ -11,6 +11,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   MAX_JOBS: 64
   MIN_PROJECTS_PER_JOB: 4
@@ -25,15 +32,18 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       changed_projects: ${{ steps.analyze.outputs.changed_projects }}
       total_projects: ${{ steps.analyze.outputs.total_projects }}
       matrix: ${{ steps.matrix.outputs.matrix }}
+      projects_per_job: ${{ steps.matrix.outputs.projects_per_job }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         if: github.event_name == 'pull_request'
         with:
@@ -89,6 +99,7 @@ jobs:
 
           if [ "$total_projects" -lt "$min_projects_for_matrix" ]; then
             echo "matrix=[0]" >> $GITHUB_OUTPUT
+            echo "projects_per_job=$total_projects" >> $GITHUB_OUTPUT
           else
             projects_per_job=$(( (total_projects + max_jobs - 1) / max_jobs ))
             projects_per_job=$(( projects_per_job > min_projects_per_job ? projects_per_job : min_projects_per_job ))
@@ -96,12 +107,14 @@ jobs:
 
             indices=$(seq 0 $(( num_jobs - 1 )))
             echo "matrix=[$(echo $indices | tr ' ' ',')]" >> $GITHUB_OUTPUT
+            echo "projects_per_job=$projects_per_job" >> $GITHUB_OUTPUT
           fi
 
   build-and-test:
     needs: changes
     if: needs.changes.outputs.total_projects != '0'
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +124,7 @@ jobs:
       failed_projects: ${{ steps.set-failed.outputs.failed_projects }}
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
@@ -172,8 +185,8 @@ jobs:
             local solana_version=$1
 
             readarray -t all_projects < <(echo '${{ needs.changes.outputs.changed_projects }}' | jq -r '.[]?')
-            start_index=$(( ${{ matrix.index }} * ${{ env.MIN_PROJECTS_PER_JOB }} ))
-            end_index=$(( start_index + ${{ env.MIN_PROJECTS_PER_JOB }} ))
+            start_index=$(( ${{ matrix.index }} * ${{ needs.changes.outputs.projects_per_job }} ))
+            end_index=$(( start_index + ${{ needs.changes.outputs.projects_per_job }} ))
             end_index=$(( end_index > ${{ needs.changes.outputs.total_projects }} ? ${{ needs.changes.outputs.total_projects }} : end_index ))
 
             echo "Projects to build and test in this job"
@@ -198,7 +211,7 @@ jobs:
           chmod +x build_and_test.sh
 
       - name: Setup Solana Stable
-        uses: heyAyushh/setup-solana@v5.9
+        uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:
           solana-cli-version: stable
       - name: Build and Test with Stable
@@ -212,7 +225,7 @@ jobs:
       # with heyAyushh/setup-solana — beta setup clears the stable install first.
       - name: Setup Solana Beta
         continue-on-error: true
-        uses: heyAyushh/setup-solana@v5.9
+        uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:
           solana-cli-version: beta
       - name: Build and Test with Beta
@@ -238,6 +251,7 @@ jobs:
     needs: [changes, build-and-test]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Create job summary

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -9,6 +9,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -17,9 +24,10 @@ jobs:
   biome:
     name: Biome check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
- Fix matrix slicing stride: jobs sliced with hardcoded
  MIN_PROJECTS_PER_JOB while the matrix was sized with the computed
  projects_per_job, silently skipping projects once a project type
  crosses 256 directories. Slicing now uses the computed value.
- Cancel superseded in-progress runs on PR pushes (concurrency groups).
- Add timeout-minutes to every job so a hung validator cannot run to
  the 6-hour ceiling.
- Add least-privilege top-level permissions (contents: read).
- Pin third-party actions (dorny/paths-filter, pnpm/action-setup,
  extractions/setup-just, heyAyushh/setup-solana,
  dtolnay/rust-toolchain) to full commit SHAs; upgrade solana-asm's
  paths-filter from v3 to the same pinned v4 used elsewhere.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>