### PR TITLE
ci: run Solana beta legs on nightly schedule only

### DIFF
--- a/.github/workflows/solana-asm.yml
+++ b/.github/workflows/solana-asm.yml
@@ -222,21 +222,34 @@ jobs:
           solana -V
           rustc -V
           process_projects "stable"
-      # continue-on-error because the beta channel may not have a valid release
-      # (e.g. v4.0 returns 404 from release.anza.xyz). This is an upstream issue
-      # with heyAyushh/setup-solana — beta setup clears the stable install first.
+      # Beta runs only on the nightly schedule and never blocks: the beta
+      # channel may not have a valid release (e.g. v4.0 returns 404 from
+      # release.anza.xyz — upstream issue with heyAyushh/setup-solana), and
+      # beta setup clears the stable install first.
       - name: Setup Solana Beta
+        id: setup-beta
+        if: github.event_name == 'schedule'
         continue-on-error: true
         uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:
           solana-cli-version: beta
       - name: Build and Test with Beta
+        id: test-beta
+        if: github.event_name == 'schedule' && steps.setup-beta.outcome == 'success'
         continue-on-error: true
         run: |
           source build_and_test.sh
           solana -V
           rustc -V
           process_projects "beta"
+      - name: Report Beta outcome
+        if: github.event_name == 'schedule'
+        run: |
+          case "${{ steps.setup-beta.outcome }}/${{ steps.test-beta.outcome }}" in
+            success/success) echo ":white_check_mark: Beta: build and tests passed" >> $GITHUB_STEP_SUMMARY ;;
+            success/*) echo ":x: Beta: build or tests failed (non-blocking)" >> $GITHUB_STEP_SUMMARY ;;
+            *) echo ":warning: Beta: skipped — beta toolchain setup failed (channel likely has no release)" >> $GITHUB_STEP_SUMMARY ;;
+          esac
 
       - name: Set failed projects output
         id: set-failed

--- a/.github/workflows/solana-native.yml
+++ b/.github/workflows/solana-native.yml
@@ -220,21 +220,34 @@ jobs:
           solana -V
           rustc -V
           process_projects "stable"
-      # continue-on-error because the beta channel may not have a valid release
-      # (e.g. v4.0 returns 404 from release.anza.xyz). This is an upstream issue
-      # with heyAyushh/setup-solana — beta setup clears the stable install first.
+      # Beta runs only on the nightly schedule and never blocks: the beta
+      # channel may not have a valid release (e.g. v4.0 returns 404 from
+      # release.anza.xyz — upstream issue with heyAyushh/setup-solana), and
+      # beta setup clears the stable install first.
       - name: Setup Solana Beta
+        id: setup-beta
+        if: github.event_name == 'schedule'
         continue-on-error: true
         uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:
           solana-cli-version: beta
       - name: Build and Test with Beta
+        id: test-beta
+        if: github.event_name == 'schedule' && steps.setup-beta.outcome == 'success'
         continue-on-error: true
         run: |
           source build_and_test.sh
           solana -V
           rustc -V
           process_projects "beta"
+      - name: Report Beta outcome
+        if: github.event_name == 'schedule'
+        run: |
+          case "${{ steps.setup-beta.outcome }}/${{ steps.test-beta.outcome }}" in
+            success/success) echo ":white_check_mark: Beta: build and tests passed" >> $GITHUB_STEP_SUMMARY ;;
+            success/*) echo ":x: Beta: build or tests failed (non-blocking)" >> $GITHUB_STEP_SUMMARY ;;
+            *) echo ":warning: Beta: skipped — beta toolchain setup failed (channel likely has no release)" >> $GITHUB_STEP_SUMMARY ;;
+          esac
 
       - name: Set failed projects output
         id: set-failed

--- a/.github/workflows/solana-pinocchio.yml
+++ b/.github/workflows/solana-pinocchio.yml
@@ -220,21 +220,34 @@ jobs:
           solana -V
           rustc -V
           process_projects "stable"
-      # continue-on-error because the beta channel may not have a valid release
-      # (e.g. v4.0 returns 404 from release.anza.xyz). This is an upstream issue
-      # with heyAyushh/setup-solana — beta setup clears the stable install first.
+      # Beta runs only on the nightly schedule and never blocks: the beta
+      # channel may not have a valid release (e.g. v4.0 returns 404 from
+      # release.anza.xyz — upstream issue with heyAyushh/setup-solana), and
+      # beta setup clears the stable install first.
       - name: Setup Solana Beta
+        id: setup-beta
+        if: github.event_name == 'schedule'
         continue-on-error: true
         uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:
           solana-cli-version: beta
       - name: Build and Test with Beta
+        id: test-beta
+        if: github.event_name == 'schedule' && steps.setup-beta.outcome == 'success'
         continue-on-error: true
         run: |
           source build_and_test.sh
           solana -V
           rustc -V
           process_projects "beta"
+      - name: Report Beta outcome
+        if: github.event_name == 'schedule'
+        run: |
+          case "${{ steps.setup-beta.outcome }}/${{ steps.test-beta.outcome }}" in
+            success/success) echo ":white_check_mark: Beta: build and tests passed" >> $GITHUB_STEP_SUMMARY ;;
+            success/*) echo ":x: Beta: build or tests failed (non-blocking)" >> $GITHUB_STEP_SUMMARY ;;
+            *) echo ":warning: Beta: skipped — beta toolchain setup failed (channel likely has no release)" >> $GITHUB_STEP_SUMMARY ;;
+          esac
 
       - name: Set failed projects output
         id: set-failed


### PR DESCRIPTION
Beta setup and test steps were continue-on-error on every PR and push,
so they doubled build time while never blocking, and a beta 404 left a
soft-failed step indistinguishable from a pass. Beta now runs only on
the nightly schedule, skips the test leg when beta setup fails, and
reports passed/failed/skipped explicitly in the job summary.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>