### PR TITLE
ci: cache pnpm store, cargo registry, and sbpf binary

### DIFF
--- a/.github/actions/setup-anchor/action.yml
+++ b/.github/actions/setup-anchor/action.yml
@@ -28,6 +28,8 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
+        cache: pnpm
+        cache-dependency-path: '**/pnpm-lock.yaml'
     
     - name: Output Node Version
       id: node_v

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -124,6 +124,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: cargo-registry
+          cache-targets: false
       - uses: ./.github/actions/setup-anchor
         with:
           anchor-version: 1.0.2

--- a/.github/workflows/just.yml
+++ b/.github/workflows/just.yml
@@ -101,6 +101,12 @@ jobs:
         with:
           node-version-file: ${{ matrix.project }}/.nvmrc
           check-latest: true
+          cache: pnpm
+          cache-dependency-path: ${{ matrix.project }}/pnpm-lock.yaml
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ${{ matrix.project }}
+          shared-key: ${{ matrix.project }}
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
       - name: Setup Solana

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: clippy
       - name: Linting
         # Allow diverging_sub_expression: false positive from Anchor 1.0's #[program] macro expansion
         run: cargo clippy -- -D warnings -A clippy::diverging_sub_expression

--- a/.github/workflows/solana-asm.yml
+++ b/.github/workflows/solana-asm.yml
@@ -122,11 +122,33 @@ jobs:
       failed_projects: ${{ steps.set-failed.outputs.failed_projects }}
     steps:
       - uses: actions/checkout@v7
+      # pnpm/action-setup installs the packageManager version pinned in
+      # package.json (unpinned latest pnpm fails CI with ERR_PNPM_IGNORED_BUILDS)
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
           check-latest: true
+          cache: pnpm
+          cache-dependency-path: '**/pnpm-lock.yaml'
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: cargo-registry
+          cache-targets: false
+      - name: Cache sbpf assembler
+        id: cache-sbpf
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/sbpf
+          key: ${{ runner.os }}-sbpf-0223df0e7ba622d4956b4ecf3cf2397f6945b76b
+      # Pinned to v0.1.9 (0223df0e): the unpinned tip moved to v0.2.2, which
+      # emits an sBPF binary the runtime loader rejects at execution
+      # ("Program is not deployed"), breaking every ASM example. Keep in sync
+      # with the pinned Solana version below.
+      - name: Install sbpf assembler
+        if: steps.cache-sbpf.outputs.cache-hit != 'true'
+        run: cargo install --git https://github.com/blueshift-gg/sbpf.git --rev 0223df0e7ba622d4956b4ecf3cf2397f6945b76b
       - name: Setup build environment
         id: setup
         run: |
@@ -208,16 +230,6 @@ jobs:
 
           # Make the script executable
           chmod +x build_and_test.sh
-
-          # Install pnpm (pin to the repo's packageManager version; unpinned
-          # latest pnpm fails CI with ERR_PNPM_IGNORED_BUILDS)
-          npm install --global pnpm@10.33.0
-
-          # Install sbpf assembler. Pinned to v0.1.9 (0223df0e): the unpinned
-          # tip moved to v0.2.2, which emits an sBPF binary the runtime loader
-          # rejects at execution ("Program is not deployed"), breaking every ASM
-          # example. Keep in sync with the pinned Solana version below.
-          cargo install --git https://github.com/blueshift-gg/sbpf.git --rev 0223df0e7ba622d4956b4ecf3cf2397f6945b76b
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@667aa7cbe39ba7d585e752a99fb8918c870d1bac # v5.9
         with:

--- a/.github/workflows/solana-native.yml
+++ b/.github/workflows/solana-native.yml
@@ -130,6 +130,12 @@ jobs:
         with:
           node-version: 'lts/*'
           check-latest: true
+          cache: pnpm
+          cache-dependency-path: '**/pnpm-lock.yaml'
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: cargo-registry
+          cache-targets: false
       - name: Setup build environment
         id: setup
         run: |

--- a/.github/workflows/solana-pinocchio.yml
+++ b/.github/workflows/solana-pinocchio.yml
@@ -130,6 +130,12 @@ jobs:
         with:
           node-version: "lts/*"
           check-latest: true
+          cache: pnpm
+          cache-dependency-path: '**/pnpm-lock.yaml'
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: cargo-registry
+          cache-targets: false
       - name: Setup build environment
         id: setup
         run: |


### PR DESCRIPTION
No build workflow cached anything: every job re-downloaded the pnpm
store and the cargo registry, and asm recompiled the sbpf assembler
from git on every run.

- setup-node pnpm store cache keyed on all project lockfiles (per
  project lockfile for just.yml)
- Swatinem/rust-cache for the shared root-workspace cargo registry
  (cache-targets off: SBF target dirs are too large and anchor wipes
  them between projects); full target cache for the clippy job and
  per-workspace for just.yml
- asm: sbpf binary cached keyed on its pinned rev, install skipped on
  hit; pnpm now installed via pinned pnpm/action-setup reading the
  packageManager field instead of npm install -g

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>