### PR TITLE
chore: remove unnecessary fs dependency from example package.json files

### DIFF
--- a/basics/account-data/native/package.json
+++ b/basics/account-data/native/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
-    "fs": "^0.0.1-security",
     "borsh": "^2.0.0"
   },
   "devDependencies": {

--- a/basics/account-data/native/pnpm-lock.yaml
+++ b/basics/account-data/native/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       borsh:
         specifier: ^2.0.0
         version: 2.0.0
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -310,9 +307,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -973,8 +967,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/cross-program-invocation/native/package.json
+++ b/basics/cross-program-invocation/native/package.json
@@ -10,7 +10,6 @@
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
     "buffer": "^6.0.3",
-    "fs": "^0.0.1-security",
     "litesvm": "0.8.0"
   },
   "devDependencies": {

--- a/basics/cross-program-invocation/native/pnpm-lock.yaml
+++ b/basics/cross-program-invocation/native/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
       litesvm:
         specifier: 0.8.0
         version: 0.8.0(bufferutil@4.0.9)(typescript@4.9.5)(utf-8-validate@5.0.10)
@@ -314,9 +311,6 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -431,24 +425,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   litesvm-linux-arm64-musl@0.8.0:
     resolution: {integrity: sha512-g7vgYPJZC6cT1gaWA1M2SbZu+Sngs9FuxsybDSE1Mmelmaejlguf7X/ymUuhehaSjEY+QSi+ydWtwzgE95JL0w==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   litesvm-linux-x64-gnu@0.8.0:
     resolution: {integrity: sha512-nn599p+XuOJoQN2XTSaY4Yz1ZqYxLNUbvt30kImuRUs2ZlIv5FANzM+VUsZgSzWV0phW8m6stX3mpdVv0iIuFQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   litesvm-linux-x64-musl@0.8.0:
     resolution: {integrity: sha512-UH4v1GM4hNOjEIzx/dBZQ5mxWGFOd85qs7IBou070dLjH0vdZMh4avQCQyc127+A7aRfdc8+wK7t4SEIn4EEgw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   litesvm@0.8.0:
     resolution: {integrity: sha512-P0Ly11FSr1f77bKwaRf0VQQZYdsw6Oi3OLKBxgBN5iJcB7W7lTjFB1tnVcJqdn1NMz6upqU/04rZFCC/JfYBWg==}
@@ -983,8 +981,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/program-derived-addresses/native/package.json
+++ b/basics/program-derived-addresses/native/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
-    "fs": "^0.0.1-security",
     "borsh": "^2.0.0"
   },
   "devDependencies": {

--- a/basics/program-derived-addresses/native/pnpm-lock.yaml
+++ b/basics/program-derived-addresses/native/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       borsh:
         specifier: ^2.0.0
         version: 2.0.0
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -293,9 +290,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -923,8 +917,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/program-derived-addresses/pinocchio/package.json
+++ b/basics/program-derived-addresses/pinocchio/package.json
@@ -7,8 +7,7 @@
     "deploy": "solana program deploy ./program/target/so/program.so"
   },
   "dependencies": {
-    "@solana/web3.js": "^1.98.4",
-    "fs": "^0.0.1-security"
+    "@solana/web3.js": "^1.98.4"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/basics/program-derived-addresses/pinocchio/pnpm-lock.yaml
+++ b/basics/program-derived-addresses/pinocchio/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@solana/web3.js':
         specifier: ^1.98.4
         version: 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -287,9 +284,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -915,8 +909,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/realloc/native/package.json
+++ b/basics/realloc/native/package.json
@@ -8,8 +8,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
-    "borsh": "^2.0.0",
-    "fs": "^0.0.1-security"
+    "borsh": "^2.0.0"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/basics/realloc/native/pnpm-lock.yaml
+++ b/basics/realloc/native/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       borsh:
         specifier: ^2.0.0
         version: 2.0.0
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -308,9 +305,6 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -537,12 +531,14 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   solana-bankrun-linux-x64-musl@0.3.1:
     resolution: {integrity: sha512-6r8i0NuXg3CGURql8ISMIUqhE7Hx/O7MlIworK4oN08jYrP0CXdLeB/hywNn7Z8d1NXrox/NpYUgvRm2yIzAsQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   solana-bankrun@0.3.1:
     resolution: {integrity: sha512-inRwON7fBU5lPC36HdEqPeDg15FXJYcf77+o0iz9amvkUMJepcwnRwEfTNyMVpVYdgjTOBW5vg+596/3fi1kGA==}
@@ -968,8 +964,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/realloc/pinocchio/package.json
+++ b/basics/realloc/pinocchio/package.json
@@ -7,8 +7,7 @@
     "deploy": "solana program deploy ./program/target/so/program.so"
   },
   "dependencies": {
-    "@solana/web3.js": "^1.98.4",
-    "fs": "^0.0.1-security"
+    "@solana/web3.js": "^1.98.4"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/basics/realloc/pinocchio/pnpm-lock.yaml
+++ b/basics/realloc/pinocchio/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@solana/web3.js':
         specifier: ^1.98.4
         version: 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -304,9 +301,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -965,8 +959,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/rent/native/package.json
+++ b/basics/rent/native/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/basics/rent/native/pnpm-lock.yaml
+++ b/basics/rent/native/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -313,9 +310,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -976,8 +970,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/rent/pinocchio/package.json
+++ b/basics/rent/pinocchio/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/basics/rent/pinocchio/pnpm-lock.yaml
+++ b/basics/rent/pinocchio/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -313,9 +310,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -976,8 +970,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/repository-layout/native/package.json
+++ b/basics/repository-layout/native/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
-    "fs": "^0.0.1-security",
     "borsh": "^2.0.0"
   },
   "devDependencies": {

--- a/basics/repository-layout/native/pnpm-lock.yaml
+++ b/basics/repository-layout/native/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       borsh:
         specifier: ^2.0.0
         version: 2.0.0
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -310,9 +307,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -973,8 +967,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/transfer-sol/asm/package.json
+++ b/basics/transfer-sol/asm/package.json
@@ -8,8 +8,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.47.3",
-    "buffer-layout": "^1.2.2",
-    "fs": "^0.0.1-security"
+    "buffer-layout": "^1.2.2"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/basics/transfer-sol/asm/pnpm-lock.yaml
+++ b/basics/transfer-sol/asm/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       buffer-layout:
         specifier: ^1.2.2
         version: 1.2.2
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -311,9 +308,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -974,8 +968,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/transfer-sol/native/package.json
+++ b/basics/transfer-sol/native/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer-layout": "^1.2.2",
-    "fs": "^0.0.1-security"
+    "buffer-layout": "^1.2.2"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/basics/transfer-sol/native/pnpm-lock.yaml
+++ b/basics/transfer-sol/native/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       buffer-layout:
         specifier: ^1.2.2
         version: 1.2.2
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -317,9 +314,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -982,8 +976,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/basics/transfer-sol/pinocchio/package.json
+++ b/basics/transfer-sol/pinocchio/package.json
@@ -8,8 +8,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
-    "buffer-layout": "^1.2.2",
-    "fs": "^0.0.1-security"
+    "buffer-layout": "^1.2.2"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/basics/transfer-sol/pinocchio/pnpm-lock.yaml
+++ b/basics/transfer-sol/pinocchio/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       buffer-layout:
         specifier: ^1.2.2
         version: 1.2.2
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -311,9 +308,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -974,8 +968,6 @@ snapshots:
   flat@5.0.2: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/tokens/create-token/native/package.json
+++ b/tokens/create-token/native/package.json
@@ -10,8 +10,7 @@
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/tokens/create-token/native/pnpm-lock.yaml
+++ b/tokens/create-token/native/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -463,9 +460,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1400,8 +1394,6 @@ snapshots:
       is-callable: 1.2.7
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/tokens/nft-minter/native/package.json
+++ b/tokens/nft-minter/native/package.json
@@ -7,8 +7,7 @@
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/tokens/nft-minter/native/pnpm-lock.yaml
+++ b/tokens/nft-minter/native/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -463,9 +460,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1400,8 +1394,6 @@ snapshots:
       is-callable: 1.2.7
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/tokens/pda-mint-authority/native/package.json
+++ b/tokens/pda-mint-authority/native/package.json
@@ -10,8 +10,7 @@
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/tokens/pda-mint-authority/native/pnpm-lock.yaml
+++ b/tokens/pda-mint-authority/native/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -448,9 +445,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1385,8 +1379,6 @@ snapshots:
       is-callable: 1.2.7
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/tokens/spl-token-minter/native/package.json
+++ b/tokens/spl-token-minter/native/package.json
@@ -7,8 +7,7 @@
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/tokens/spl-token-minter/native/pnpm-lock.yaml
+++ b/tokens/spl-token-minter/native/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -463,9 +460,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1400,8 +1394,6 @@ snapshots:
       is-callable: 1.2.7
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/tokens/token-2022/default-account-state/native/package.json
+++ b/tokens/token-2022/default-account-state/native/package.json
@@ -10,8 +10,7 @@
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/tokens/token-2022/default-account-state/native/pnpm-lock.yaml
+++ b/tokens/token-2022/default-account-state/native/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -451,9 +448,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1388,8 +1382,6 @@ snapshots:
       is-callable: 1.2.7
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/tokens/token-2022/mint-close-authority/native/package.json
+++ b/tokens/token-2022/mint-close-authority/native/package.json
@@ -10,8 +10,7 @@
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/tokens/token-2022/mint-close-authority/native/pnpm-lock.yaml
+++ b/tokens/token-2022/mint-close-authority/native/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -448,9 +445,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1385,8 +1379,6 @@ snapshots:
       is-callable: 1.2.7
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/tokens/token-2022/multiple-extensions/native/package.json
+++ b/tokens/token-2022/multiple-extensions/native/package.json
@@ -10,8 +10,7 @@
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/tokens/token-2022/multiple-extensions/native/pnpm-lock.yaml
+++ b/tokens/token-2022/multiple-extensions/native/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -451,9 +448,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1388,8 +1382,6 @@ snapshots:
       is-callable: 1.2.7
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/tokens/token-2022/non-transferable/native/package.json
+++ b/tokens/token-2022/non-transferable/native/package.json
@@ -10,8 +10,7 @@
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/tokens/token-2022/non-transferable/native/pnpm-lock.yaml
+++ b/tokens/token-2022/non-transferable/native/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -448,9 +445,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1385,8 +1379,6 @@ snapshots:
       is-callable: 1.2.7
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/tokens/token-2022/transfer-fee/native/package.json
+++ b/tokens/token-2022/transfer-fee/native/package.json
@@ -10,8 +10,7 @@
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/tokens/token-2022/transfer-fee/native/pnpm-lock.yaml
+++ b/tokens/token-2022/transfer-fee/native/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -448,9 +445,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1385,8 +1379,6 @@ snapshots:
       is-callable: 1.2.7
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true

--- a/tokens/transfer-tokens/native/package.json
+++ b/tokens/transfer-tokens/native/package.json
@@ -7,8 +7,7 @@
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "^1.98.4",
     "borsh": "^2.0.0",
-    "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/tokens/transfer-tokens/native/pnpm-lock.yaml
+++ b/tokens/transfer-tokens/native/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      fs:
-        specifier: ^0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -463,9 +460,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1400,8 +1394,6 @@ snapshots:
       is-callable: 1.2.7
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.3:
     optional: true


### PR DESCRIPTION
## Summary

22 example `package.json` files list `"fs": "^0.0.1-security"` as a dependency. This isn't Node's built-in `fs` module — it's npm's official security-holding placeholder for a package name no longer in use. Per the registry:

> This package name is not currently in use, but was formerly occupied by another package. To avoid malicious use, npm is hanging on to the package name, but loosely...

It resolves to a do-nothing stub and was never imported by any of these examples' source code — likely leftover from an old template that was copy-pasted forward.

Node's built-in `fs`/`node:fs` module — which several of these examples do use in their tests to read keypair fixtures off disk — is compiled into the Node runtime and resolves independently of `node_modules`, so it's completely unaffected by removing this npm entry.

## Changes

- Removed the `fs` line from `dependencies` in 22 `package.json` files (`basics/` and `tokens/`, across native/pinocchio/asm variants)
- Regenerated the corresponding `pnpm-lock.yaml` for each (pure removal — verified each lockfile diff is exactly the 8-line `fs` package entry, nothing else)

## Test plan

Verified locally across all 22 affected examples:
- [x] `pnpm install` succeeds in all 22
- [x] `cargo build-sbf` + full test execution passes for all 12 examples this repo's CI actively tracks (not in `.github/.ghaignore`)
- [x] The 10 examples already excluded from CI (pre-existing, unrelated reasons — stale TypeScript peer deps, a Cargo workspace-membership issue in `tokens/create-token/native` and `tokens/pda-mint-authority/native`) show the same pre-existing behavior as `main`; confirmed via `git diff main -- Cargo.toml Cargo.lock` that this PR touches neither
- [x] Of the 7 examples whose tests actually use Node's built-in `fs.readFileSync`, 5 ran their full test suite successfully post-change (the other 2 hit the pre-existing, unrelated Cargo workspace issue before reaching that code path)
- [x] `grep` confirms no remaining `"fs":` references in any `package.json` in the repo