### PR TITLE
ci: close stale pull requests automatically

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,35 @@
+name: Stale PRs
+
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # PRs only — issues are often long-lived example requests.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 45
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          exempt-pr-labels: keep-open
+          exempt-draft-pr: true
+          stale-pr-message: >
+            This PR has had no activity for 45 days. If it's still relevant,
+            rebase it onto current main and make sure it follows the repo
+            conventions (see AGENTS.md and CONTRIBUTING.md) — any push or
+            comment resets this timer. Add the `keep-open` label to opt out.
+            Otherwise it will be closed in 14 days.
+          close-pr-message: >
+            Closed for inactivity. Feel free to reopen or resubmit against
+            current main if you pick this back up.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,7 +28,8 @@ jobs:
             This PR has had no activity for 45 days. If it's still relevant,
             rebase it onto current main and make sure it follows the repo
             conventions (see AGENTS.md and CONTRIBUTING.md) — any push or
-            comment resets this timer. Add the `keep-open` label to opt out.
+            comment resets this timer. Ask a maintainer to add the `keep-open`
+            label to opt out.
             Otherwise it will be closed in 14 days.
           close-pr-message: >
             Closed for inactivity. Feel free to reopen or resubmit against


### PR DESCRIPTION
## Summary
- Adds a daily `actions/stale@v9` workflow scoped to pull requests only: 45 days of inactivity applies a `stale` label and a warning comment; 14 more days closes the PR
- Issues are explicitly excluded (`days-before-issue-stale: -1`) — example requests are often legitimately long-lived
- Draft PRs and anything labeled `keep-open` are exempt; any push or comment resets the clock
- The stale message points contributors at AGENTS.md/CONTRIBUTING so "what does this PR need" has an answer

## Test Plan
- `workflow_dispatch` trigger included — run it manually once merged and check the dry pass against the current PR list (the 10 recently-triaged PRs all have fresh activity, so nothing should be labeled)