### PR TITLE
fix(escrow): use accountsPartial instead of deprecated accounts in tests

### DIFF
--- a/tokens/escrow/anchor/tests/escrow.test.ts
+++ b/tokens/escrow/anchor/tests/escrow.test.ts
@@ -129,7 +129,7 @@ describe('escrow', async () => {
 
         const transactionSignature = await program.methods
             .makeOffer(offerId, tokenAOfferedAmount, tokenBWantedAmount)
-            .accounts({ ...accounts })
+            .accountsPartial({ ...accounts })
             .signers([alice])
             .rpc();
 
@@ -152,7 +152,7 @@ describe('escrow', async () => {
     it("Puts the tokens from the vault into Bob's account, and gives Alice Bob's tokens, when Bob takes an offer", async () => {
         const transactionSignature = await program.methods
             .takeOffer()
-            .accounts({ ...accounts })
+            .accountsPartial({ ...accounts })
             .signers([bob])
             .rpc();
 

--- a/tokens/escrow/anchor/tests/litesvm.test.ts
+++ b/tokens/escrow/anchor/tests/litesvm.test.ts
@@ -152,7 +152,7 @@ describe('Escrow LiteSVM example', () => {
 
         const _transactionSignature = await program.methods
             .makeOffer(offerId, tokenAOfferedAmount, tokenBWantedAmount)
-            .accounts({ ...accounts })
+            .accountsPartial({ ...accounts })
             .signers([alice])
             .rpc();
 
@@ -174,7 +174,7 @@ describe('Escrow LiteSVM example', () => {
     const take = async () => {
         const _transactionSignature = await program.methods
             .takeOffer()
-            .accounts({ ...accounts })
+            .accountsPartial({ ...accounts })
             .signers([bob])
             .rpc();
 


### PR DESCRIPTION
## What
Replaces deprecated `.accounts()` calls with `.accountsPartial()` in the 
escrow test suite, removing the TypeScript deprecation warning.

## Why
Anchor's `.accounts()` method is deprecated in favor of `.accountsPartial()`, 
which lets Anchor auto-resolve PDA accounts from seeds. Tests currently 
trigger a TS warning; this fix aligns with the tooling migration already 
in progress elsewhere in this repo.

## Testing
`anchor test` passes cleanly with no warnings after the change.