### PR TITLE
fix: repair stale/broken links across 4 READMEs

### DIFF
--- a/basics/close-account/anchor/README.md
+++ b/basics/close-account/anchor/README.md
@@ -1,34 +1,37 @@
-# Destroy an Account
+# Close an Account
 
-1. We're creating a `PDA` using [create_user.rs](programs/destroy-an-account/src/instructions/create_user.rs)
+1. We're creating a `PDA` using [create_user.rs](programs/close-account/src/instructions/create_user.rs)
    instruction.
 
     ```rust
     #[account(
     init,
-    seeds=[User::PREFIX.as_bytes(), user.key().as_ref()],
     payer=user,
-    space=User::SIZE,
+    space=UserState::INIT_SPACE,
+    seeds=[b"USER", user.key().as_ref()],
     bump
     )]
-    pub user_account: Box<Account<'info, User>>,
+    pub user_account: Account<'info, UserState>,
     ```
 
-2. We're closing it using [destroy_user.rs](programs/destroy-an-account/src/instructions/destroy_user.rs)
-   instruction, which uses `Anchor` `AccoutClose` `trait`.
+2. We're closing it using [close_user.rs](programs/close-account/src/instructions/close_user.rs)
+   instruction, which uses the `close` account constraint to close the account and return its
+   lamports to `user`.
 
     ```rust
-    user_account.close(user.to_account_info())?;
+    #[account(
+    mut,
+    seeds=[b"USER", user.key().as_ref()],
+    bump=user_account.bump,
+    close=user, // close account and return lamports to user
+    )]
+    pub user_account: Account<'info, UserState>,
     ```
 
-3. In our test [destroy-an-account.ts](tests/destroy-an-account.ts) we're using `fetchNullable` since we expect
-   the account to be `null` prior to creation and after closing.
+3. In our test [test.ts](tests/test.ts) we're using `fetchNullable` after closing the account,
+   since a closed account no longer exists and should resolve to `null`.
 
     ```typescript
-    const userAccountBefore = await program.account.user.fetchNullable(userAccountAddress, "processed");
-    assert.equal(userAccountBefore, null);
-    ...
-    ...
-    const userAccountAfter = await program.account.user.fetchNullable(userAccountAddress, "processed");
-    assert.notEqual(userAccountAfter, null);
+    const userAccount = await program.account.userState.fetchNullable(userAccountAddress);
+    assert.equal(userAccount, null);
     ```

--- a/basics/favorites/anchor/README.md
+++ b/basics/favorites/anchor/README.md
@@ -2,7 +2,7 @@
 
 This is a basic Anchor app using PDAs to store data for a user, and Anchor's account checks to ensure each user is only allowed to modify their own data.
 
-It's used by the [https://github.com/solana-developers/professional-education](Solana Professional Education) course.
+It's used by the [Solana Professional Education](https://github.com/solana-developers/professional-education) course.
 
 ## Usage
 

--- a/tokens/token-2022/nft-meta-data-pointer/README.md
+++ b/tokens/token-2022/nft-meta-data-pointer/README.md
@@ -336,7 +336,7 @@ The project uses session keys (maintained by Magic Block) for auto approving tra
 
 Many casual games in traditional gaming use energy systems. This is how you can build it on chain.
 
-If you have no prior knowledge in solana and rust programming it is recommended to start with the Solana cookbook [Hello world example](<[https://unity.com/](https://solanacookbook.com/gaming/hello-world.html#getting-started-with-your-first-solana-game)>).
+If you have no prior knowledge in solana and rust programming it is recommended to start with the Solana cookbook [Hello world example](https://solanacookbook.com/gaming/hello-world.html#getting-started-with-your-first-solana-game).
 
 ## Anchor program
 

--- a/tokens/transfer-tokens/README.md
+++ b/tokens/transfer-tokens/README.md
@@ -4,4 +4,4 @@ Just like with minting, transfers of SPL Tokens are conducted between Associated
 
 You can use the `transfer()` function provided by the SPL Token Program to conduct a transfer of any SPL Token with the appropriate permissions.
 
-Check out [SPL Token Minter](../spl-token-minter) or [NFT Minter](../nft-minter) to learn more about Associated Token Accounts.
+Check out [Create an SPL Token](../create-token) or [NFT Operations](../nft-operations) to learn more about Associated Token Accounts.

--- a/tokens/transfer-tokens/README.md
+++ b/tokens/transfer-tokens/README.md
@@ -4,4 +4,4 @@ Just like with minting, transfers of SPL Tokens are conducted between Associated
 
 You can use the `transfer()` function provided by the SPL Token Program to conduct a transfer of any SPL Token with the appropriate permissions.
 
-Check out [Create an SPL Token](../create-token) or [NFT Operations](../nft-operations) to learn more about Associated Token Accounts.
+Check out [Create an SPL Token](../create-token) and [NFT Operations](../nft-operations) for related token creation and NFT examples.


### PR DESCRIPTION
## Summary

Ran a systematic sweep over every `README.md`/`readme.MD`/`*.mdx` in the repo — 47 markdown files, 119 relative links extracted and resolved against disk — and found 4 files with genuinely broken content. Each was verified by hand against the current source it's supposed to document (not just a link-existence check).

- **`basics/close-account/anchor/README.md`** — the program was renamed from `destroy-an-account` to `close-account` (directory, file names, *and* implementation approach all changed — `close_user.rs` now uses a declarative `close = user` account constraint instead of the old imperative `.close()` call), but the README was never updated. This is the meatiest fix: 3 dead links, 2 stale code snippets rewritten to match current source, and the test-description prose corrected (the old README described checking `fetchNullable` both before creation and after closing; the current test only checks null after closing).
- **`basics/favorites/anchor/README.md`** — link text and URL were swapped: `[url](text)` instead of `[text](url)`.
- **`tokens/transfer-tokens/README.md`** — links to `tokens/spl-token-minter` and `tokens/nft-minter`, neither of which exists. Repointed to the current equivalents covering the same topics: `tokens/create-token` and `tokens/nft-operations`.
- **`tokens/token-2022/nft-meta-data-pointer/README.md`** — a copy-paste artifact had merged two separate links into one broken nested construct; restored the single intended cookbook link.

All docs-only, zero code/build risk.

## Test plan

- [x] Re-ran the link-resolution sweep after editing — 0 broken relative links out of 119 (down from 7 broken across these 4 files before)
- [x] Verified every replacement target exists with exact case via `git ls-files` (what Linux CI sees, not macOS's case-insensitive filesystem)
- [x] Manually re-read `close-account/anchor/README.md` end-to-end against `create_user.rs`, `close_user.rs`, and `tests/test.ts` to confirm the rewritten snippets/prose are accurate to current code
- [x] Repo-wide search for other references to the old renamed paths (`destroy-an-account`, `spl-token-minter`, `nft-minter`) — none found outside these files