### PR TITLE
security: add missing authorization checks in close-account and transfer-sol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,7 @@ dependencies = [
  "pinocchio-log",
  "pinocchio-system",
  "solana-instruction",
+ "solana-instruction-error",
  "solana-keypair",
  "solana-message 4.4.0",
  "solana-native-token",
@@ -1073,6 +1074,7 @@ dependencies = [
  "solana-signer",
  "solana-system-interface 2.0.0",
  "solana-transaction 3.1.0",
+ "solana-transaction-error",
 ]
 
 [[package]]
@@ -6052,11 +6054,13 @@ dependencies = [
  "pinocchio",
  "pinocchio-system",
  "solana-instruction",
+ "solana-instruction-error",
  "solana-keypair",
  "solana-native-token",
  "solana-pubkey 3.0.0",
  "solana-system-interface 2.0.0",
  "solana-transaction 3.1.0",
+ "solana-transaction-error",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ pinocchio-associated-token-account = "0.4.0"
 # testing
 litesvm = "0.11.0"
 solana-instruction = "3.0.0"
+solana-instruction-error = "2.3.0"
 solana-keypair = "3.0.1"
 solana-message = "4.0.0"
 solana-native-token = "3.0.0"

--- a/basics/close-account/native/program/src/instructions/close_user.rs
+++ b/basics/close-account/native/program/src/instructions/close_user.rs
@@ -20,7 +20,8 @@ pub fn close_user(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResul
     }
 
     // Verify target_account is actually payer's User PDA, not another user's account.
-    let (expected_user_pda, _) = Pubkey::find_program_address(&[User::SEED_PREFIX.as_bytes(), payer.key.as_ref()], program_id);
+    let (expected_user_pda, _) =
+        Pubkey::find_program_address(&[User::SEED_PREFIX.as_bytes(), payer.key.as_ref()], program_id);
     if target_account.key != &expected_user_pda {
         return Err(ProgramError::IncorrectProgramId);
     }

--- a/basics/close-account/native/program/src/instructions/close_user.rs
+++ b/basics/close-account/native/program/src/instructions/close_user.rs
@@ -1,15 +1,29 @@
+use crate::state::user::User;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
     rent::Rent,
     sysvar::Sysvar,
 };
 
-pub fn close_user(accounts: &[AccountInfo]) -> ProgramResult {
+pub fn close_user(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let target_account = next_account_info(accounts_iter)?;
     let payer = next_account_info(accounts_iter)?;
     let system_program = next_account_info(accounts_iter)?;
+
+    // Only the account's owner may close it.
+    if !payer.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    // Verify target_account is actually payer's User PDA, not another user's account.
+    let (expected_user_pda, _) = Pubkey::find_program_address(&[User::SEED_PREFIX.as_bytes(), payer.key.as_ref()], program_id);
+    if target_account.key != &expected_user_pda {
+        return Err(ProgramError::IncorrectProgramId);
+    }
 
     let account_span = 0usize;
     let lamports_required = (Rent::get()?).minimum_balance(account_span);

--- a/basics/close-account/native/program/src/processor.rs
+++ b/basics/close-account/native/program/src/processor.rs
@@ -14,6 +14,6 @@ pub fn process_instruction(program_id: &Pubkey, accounts: &[AccountInfo], input:
     let instruction = MyInstruction::try_from_slice(input)?;
     match instruction {
         MyInstruction::CreateUser(data) => create_user(program_id, accounts, data),
-        MyInstruction::CloseUser => close_user(accounts),
+        MyInstruction::CloseUser => close_user(program_id, accounts),
     }
 }

--- a/basics/close-account/native/tests/close-account.test.ts
+++ b/basics/close-account/native/tests/close-account.test.ts
@@ -68,6 +68,11 @@ describe('Close Account!', () => {
 
         const result = svm.sendTransaction(signedTx);
         assert(result instanceof FailedTransactionMetadata, 'expected the attacker transaction to fail');
+        assert.include(
+            result.err().toString(),
+            'IncorrectProgramId',
+            `expected the attacker's target PDA to be rejected as not belonging to them, got: ${result.toString()}`,
+        );
     });
 
     it('Close the account', async () => {

--- a/basics/close-account/native/tests/close-account.test.ts
+++ b/basics/close-account/native/tests/close-account.test.ts
@@ -48,6 +48,28 @@ describe('Close Account!', () => {
         assert(!(result instanceof FailedTransactionMetadata), `transaction failed: ${result.toString()}`);
     });
 
+    it("An attacker cannot close another user's account", async () => {
+        // The attacker signs with their own key, but passes the victim's
+        // (payer's) User PDA as the account to close. Without a check that
+        // the target PDA actually belongs to the signer, this would drain
+        // the victim's account into the attacker's.
+        const attacker = await generateKeyPairSigner();
+        svm.airdrop(attacker.address, lamports(1_000_000_000n));
+
+        const ix = createCloseUserInstruction(testAccountAddress, attacker, programId);
+
+        const transactionMessage = pipe(
+            createTransactionMessage({ version: 0 }),
+            m => setTransactionMessageFeePayerSigner(attacker, m),
+            m => svm.setTransactionMessageLifetimeUsingLatestBlockhash(m),
+            m => appendTransactionMessageInstruction(ix, m),
+        );
+        const signedTx = await signTransactionMessageWithSigners(transactionMessage);
+
+        const result = svm.sendTransaction(signedTx);
+        assert(result instanceof FailedTransactionMetadata, 'expected the attacker transaction to fail');
+    });
+
     it('Close the account', async () => {
         const ix = createCloseUserInstruction(testAccountAddress, payer, programId);
 

--- a/basics/close-account/pinocchio/program/Cargo.toml
+++ b/basics/close-account/pinocchio/program/Cargo.toml
@@ -10,14 +10,16 @@ pinocchio-system.workspace = true
 
 [dev-dependencies]
 litesvm.workspace = true
+solana-instruction.workspace = true
+solana-instruction-error.workspace = true
 solana-keypair.workspace = true
 solana-message.workspace = true
 solana-native-token.workspace = true
 solana-pubkey.workspace = true
 solana-signer.workspace = true
 solana-transaction.workspace = true
+solana-transaction-error.workspace = true
 solana-system-interface.workspace = true
-solana-instruction.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/basics/close-account/pinocchio/program/src/lib.rs
+++ b/basics/close-account/pinocchio/program/src/lib.rs
@@ -17,7 +17,7 @@ nostd_panic_handler!();
 fn process_instruction(program_id: &Address, accounts: &mut [AccountView], instruction_data: &[u8]) -> ProgramResult {
     match instruction_data.split_first() {
         Some((&CREATE_DISCRIMINATOR, data)) => process_user(program_id, accounts, data),
-        Some((&CLOSE_DISCRIMINATOR, _)) => process_close(accounts),
+        Some((&CLOSE_DISCRIMINATOR, _)) => process_close(program_id, accounts),
         _ => Err(ProgramError::InvalidInstructionData),
     }
 }
@@ -65,10 +65,22 @@ fn process_user(program_id: &Address, accounts: &mut [AccountView], instruction_
     Ok(())
 }
 
-fn process_close(accounts: &mut [AccountView]) -> ProgramResult {
+fn process_close(program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
     let [target_account, payer, system_program] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
+
+    // Only the account's owner may close it.
+    if !payer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    // Verify target_account is actually payer's User PDA, not another user's account.
+    let (expected_user_pda, _) =
+        Address::find_program_address(&[User::SEED_PREFIX.as_bytes(), payer.address().as_ref()], program_id);
+    if target_account.address() != &expected_user_pda {
+        return Err(ProgramError::IncorrectProgramId);
+    }
 
     let rent = Rent::get()?;
 

--- a/basics/close-account/pinocchio/program/tests/tests.rs
+++ b/basics/close-account/pinocchio/program/tests/tests.rs
@@ -53,6 +53,32 @@ fn test_close_account() {
     assert_eq!(account.owner, program_id);
     assert_eq!(&account.data[..5], b"Jacob");
 
+    // An attacker cannot close another user's account: the attacker signs
+    // with their own key, but passes the victim's User PDA as the account
+    // to close. Without a check that the target PDA actually belongs to the
+    // signer, this would drain the victim's account into the attacker's.
+    let attacker = Keypair::new();
+    svm.airdrop(&attacker.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+    let mut data = Vec::new();
+    data.push(CLOSE_DISCRIMINATOR);
+
+    let attack_ix = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(test_account_pubkey, false),
+            AccountMeta::new(attacker.pubkey(), true),
+            AccountMeta::new(solana_system_interface::program::ID, false),
+        ],
+        data,
+    };
+
+    let tx =
+        Transaction::new_signed_with_payer(&[attack_ix], Some(&attacker.pubkey()), &[&attacker], svm.latest_blockhash());
+
+    let res = svm.send_transaction(tx);
+    assert!(res.is_err(), "expected the attacker transaction to fail");
+
     // process_close
     let mut data = Vec::new();
     data.push(CLOSE_DISCRIMINATOR);

--- a/basics/close-account/pinocchio/program/tests/tests.rs
+++ b/basics/close-account/pinocchio/program/tests/tests.rs
@@ -1,9 +1,11 @@
 use litesvm::LiteSVM;
 use solana_instruction::{AccountMeta, Instruction};
+use solana_instruction_error::InstructionError;
 use solana_keypair::{Keypair, Signer};
 use solana_native_token::LAMPORTS_PER_SOL;
 use solana_pubkey::Pubkey;
 use solana_transaction::Transaction;
+use solana_transaction_error::TransactionError;
 
 use close_account_pinocchio_program::{User, CLOSE_DISCRIMINATOR, CREATE_DISCRIMINATOR};
 
@@ -81,7 +83,12 @@ fn test_close_account() {
     );
 
     let res = svm.send_transaction(tx);
-    assert!(res.is_err(), "expected the attacker transaction to fail");
+    let err = res.expect_err("expected the attacker transaction to fail").err;
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::IncorrectProgramId),
+        "expected the attacker's target PDA to be rejected as not belonging to them"
+    );
 
     // process_close
     let mut data = Vec::new();

--- a/basics/close-account/pinocchio/program/tests/tests.rs
+++ b/basics/close-account/pinocchio/program/tests/tests.rs
@@ -73,8 +73,12 @@ fn test_close_account() {
         data,
     };
 
-    let tx =
-        Transaction::new_signed_with_payer(&[attack_ix], Some(&attacker.pubkey()), &[&attacker], svm.latest_blockhash());
+    let tx = Transaction::new_signed_with_payer(
+        &[attack_ix],
+        Some(&attacker.pubkey()),
+        &[&attacker],
+        svm.latest_blockhash(),
+    );
 
     let res = svm.send_transaction(tx);
     assert!(res.is_err(), "expected the attacker transaction to fail");

--- a/basics/transfer-sol/anchor/programs/transfer-sol/src/lib.rs
+++ b/basics/transfer-sol/anchor/programs/transfer-sol/src/lib.rs
@@ -41,12 +41,11 @@ pub struct TransferSolWithCpi<'info> {
 
 #[derive(Accounts)]
 pub struct TransferSolWithProgram<'info> {
-    /// CHECK: Use owner constraint to check account is owned by our program
     #[account(
         mut,
         owner = id() // value of declare_id!()
     )]
-    payer: UncheckedAccount<'info>,
+    payer: Signer<'info>,
     #[account(mut)]
     recipient: SystemAccount<'info>,
 }

--- a/basics/transfer-sol/anchor/tests/litesvm.test.ts
+++ b/basics/transfer-sol/anchor/tests/litesvm.test.ts
@@ -136,5 +136,10 @@ describe('LiteSVM: Transfer SOL', () => {
 
         const result = svm.sendTransaction(tx);
         assert(result instanceof FailedTransactionMetadata, 'expected the attacker transaction to fail');
+        assert.include(
+            result.err().toString(),
+            'code: 3010',
+            `expected Anchor's AccountNotSigner error (code 3010: "The given account did not sign"), got: ${result.toString()}`,
+        );
     });
 });

--- a/basics/transfer-sol/anchor/tests/litesvm.test.ts
+++ b/basics/transfer-sol/anchor/tests/litesvm.test.ts
@@ -8,7 +8,7 @@ import {
     TransactionInstruction,
 } from '@solana/web3.js';
 import { assert } from 'chai';
-import { LiteSVM } from 'litesvm';
+import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 import Idl from '../target/idl/transfer_sol.json' with { type: 'json' };
 
 describe('LiteSVM: Transfer SOL', () => {
@@ -92,5 +92,49 @@ describe('LiteSVM: Transfer SOL', () => {
 
         const recipientAcc = svm.getAccount(recipientAccount.publicKey);
         assert.equal(recipientAcc.lamports, LAMPORTS_PER_SOL);
+    });
+
+    it("An attacker cannot drain another user's program-owned account", () => {
+        const victimAccount = Keypair.generate();
+        const ixVictim = SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: victimAccount.publicKey,
+            lamports: LAMPORTS_PER_SOL,
+            space: 0,
+            programId,
+        });
+        const txVictim = new Transaction().add(ixVictim);
+        txVictim.feePayer = payer.publicKey;
+        txVictim.recentBlockhash = svm.latestBlockhash();
+        txVictim.sign(payer, victimAccount);
+        svm.sendTransaction(txVictim);
+        svm.expireBlockhash();
+
+        // The attacker never has victimAccount's private key. They mark it
+        // as a non-signer in the instruction and only sign with their own
+        // (unrelated) fee-payer key.
+        const attackerRecipient = Keypair.generate();
+
+        const ixArgs = {
+            amount: new anchor.BN(LAMPORTS_PER_SOL),
+        };
+        const data = coder.instruction.encode('transfer_sol_with_program', ixArgs);
+        const ix = new TransactionInstruction({
+            keys: [
+                { pubkey: victimAccount.publicKey, isSigner: false, isWritable: true },
+                { pubkey: attackerRecipient.publicKey, isSigner: false, isWritable: true },
+                { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+            ],
+            programId,
+            data,
+        });
+
+        const tx = new Transaction().add(ix);
+        tx.feePayer = payer.publicKey;
+        tx.recentBlockhash = svm.latestBlockhash();
+        tx.sign(payer);
+
+        const result = svm.sendTransaction(tx);
+        assert(result instanceof FailedTransactionMetadata, 'expected the attacker transaction to fail');
     });
 });

--- a/basics/transfer-sol/anchor/tests/test.ts
+++ b/basics/transfer-sol/anchor/tests/test.ts
@@ -46,6 +46,7 @@ describe('Anchor: Transfer SOL', () => {
                 payer: payerAccount.publicKey,
                 recipient: recipientAccount.publicKey,
             })
+            .signers([payerAccount])
             .rpc();
 
         const recipientBalance = await provider.connection.getBalance(recipientAccount.publicKey);

--- a/basics/transfer-sol/native/program/src/instruction.rs
+++ b/basics/transfer-sol/native/program/src/instruction.rs
@@ -2,6 +2,7 @@ use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
     program::invoke,
+    program_error::ProgramError,
     pubkey::Pubkey,
 };
 
@@ -23,6 +24,11 @@ pub fn transfer_sol_with_program(_program_id: &Pubkey, accounts: &[AccountInfo],
     let accounts_iter = &mut accounts.iter();
     let payer = next_account_info(accounts_iter)?;
     let recipient = next_account_info(accounts_iter)?;
+
+    // Only the account's owner may move its lamports.
+    if !payer.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
 
     **payer.try_borrow_mut_lamports()? -= amount;
     **recipient.try_borrow_mut_lamports()? += amount;

--- a/basics/transfer-sol/native/tests/test.ts
+++ b/basics/transfer-sol/native/tests/test.ts
@@ -121,10 +121,7 @@ describe('transfer-sol', () => {
         );
         const attackIx = {
             ...legitIx,
-            accounts: [
-                { address: victimAccount.address, role: AccountRole.WRITABLE },
-                ...legitIx.accounts.slice(1),
-            ],
+            accounts: [{ address: victimAccount.address, role: AccountRole.WRITABLE }, ...legitIx.accounts.slice(1)],
         };
 
         const transactionMessage = pipe(

--- a/basics/transfer-sol/native/tests/test.ts
+++ b/basics/transfer-sol/native/tests/test.ts
@@ -1,5 +1,6 @@
 import {
     type Address,
+    AccountRole,
     appendTransactionMessageInstructions,
     createTransactionMessage,
     generateKeyPairSigner,
@@ -93,6 +94,48 @@ describe('transfer-sol', () => {
         await sendTransaction([ix]);
 
         getBalances(test2Recipient1.address, test2Recipient2.address, 'Resulting');
+    });
+
+    it("An attacker cannot drain another user's program-owned account", async () => {
+        const victimAccount = await generateKeyPairSigner();
+        const attackerRecipient = await generateKeyPairSigner();
+
+        const createIx = getCreateAccountInstruction({
+            payer,
+            newAccount: victimAccount,
+            space: 0,
+            lamports: 2 * LAMPORTS_PER_SOL,
+            programAddress: programId,
+        });
+        await sendTransaction([createIx]);
+
+        // The attacker never has victimAccount's private key. They build the
+        // instruction with victimAccount marked as a non-signer and only
+        // sign with their own (unrelated) fee-payer key.
+        const legitIx = createTransferInstruction(
+            victimAccount,
+            attackerRecipient.address,
+            programId,
+            InstructionType.ProgramTransfer,
+            transferAmount,
+        );
+        const attackIx = {
+            ...legitIx,
+            accounts: [
+                { address: victimAccount.address, role: AccountRole.WRITABLE },
+                ...legitIx.accounts.slice(1),
+            ],
+        };
+
+        const transactionMessage = pipe(
+            createTransactionMessage({ version: 0 }),
+            m => setTransactionMessageFeePayerSigner(payer, m),
+            m => svm.setTransactionMessageLifetimeUsingLatestBlockhash(m),
+            m => appendTransactionMessageInstructions([attackIx], m),
+        );
+        const signedTx = await signTransactionMessageWithSigners(transactionMessage);
+        const result = svm.sendTransaction(signedTx);
+        assert(result instanceof FailedTransactionMetadata, 'expected the attacker transaction to fail');
     });
 
     function getBalances(payerAddress: Address, recipientAddress: Address, timeframe: string) {

--- a/basics/transfer-sol/native/tests/test.ts
+++ b/basics/transfer-sol/native/tests/test.ts
@@ -133,6 +133,11 @@ describe('transfer-sol', () => {
         const signedTx = await signTransactionMessageWithSigners(transactionMessage);
         const result = svm.sendTransaction(signedTx);
         assert(result instanceof FailedTransactionMetadata, 'expected the attacker transaction to fail');
+        assert.include(
+            result.err().toString(),
+            'MissingRequiredSignature',
+            `expected the debit to be rejected for lacking the victim's signature, got: ${result.toString()}`,
+        );
     });
 
     function getBalances(payerAddress: Address, recipientAddress: Address, timeframe: string) {

--- a/basics/transfer-sol/pinocchio/program/Cargo.toml
+++ b/basics/transfer-sol/pinocchio/program/Cargo.toml
@@ -20,8 +20,10 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"
 [dev-dependencies]
 litesvm.workspace = true
 solana-instruction.workspace = true
+solana-instruction-error.workspace = true
 solana-keypair.workspace = true
 solana-native-token.workspace = true
 solana-pubkey.workspace = true
 solana-transaction.workspace = true
+solana-transaction-error.workspace = true
 solana-system-interface.workspace = true

--- a/basics/transfer-sol/pinocchio/program/src/lib.rs
+++ b/basics/transfer-sol/pinocchio/program/src/lib.rs
@@ -35,6 +35,11 @@ fn transfer_sol_with_program(accounts: &mut [AccountView], instruction_data: &[u
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
+    // Only the account's owner may move its lamports.
+    if !payer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
     let amount_bytes: [u8; 8] = instruction_data[0..8].try_into().map_err(|_| ProgramError::InvalidInstructionData)?;
     let amount = u64::from_le_bytes(amount_bytes);
 

--- a/basics/transfer-sol/pinocchio/program/tests/test.rs
+++ b/basics/transfer-sol/pinocchio/program/tests/test.rs
@@ -110,15 +110,11 @@ fn test_transfer_sol() {
 
     let attack_ix = Instruction {
         program_id,
-        accounts: vec![
-            AccountMeta::new(victim.pubkey(), false),
-            AccountMeta::new(attacker_recipient.pubkey(), false),
-        ],
+        accounts: vec![AccountMeta::new(victim.pubkey(), false), AccountMeta::new(attacker_recipient.pubkey(), false)],
         data,
     };
 
-    let tx =
-        Transaction::new_signed_with_payer(&[attack_ix], Some(&payer.pubkey()), &[&payer], svm.latest_blockhash());
+    let tx = Transaction::new_signed_with_payer(&[attack_ix], Some(&payer.pubkey()), &[&payer], svm.latest_blockhash());
 
     let res = svm.send_transaction(tx);
     assert!(res.is_err(), "expected the attacker transaction to fail");

--- a/basics/transfer-sol/pinocchio/program/tests/test.rs
+++ b/basics/transfer-sol/pinocchio/program/tests/test.rs
@@ -84,4 +84,42 @@ fn test_transfer_sol() {
 
     let res = svm.send_transaction(tx);
     assert!(res.is_ok());
+
+    // An attacker cannot drain another user's program-owned account. Create
+    // a fresh victim account genuinely owned by this program (unlike
+    // test_recipient3 above, which is only credited lamports and therefore
+    // stays System-Program-owned). The attacker never has the victim's
+    // private key: they mark it as a non-signer in the instruction and
+    // only sign with their own (unrelated) fee-payer key.
+    let victim = Keypair::new();
+    let attacker_recipient = Keypair::new();
+
+    let create_victim_ix = create_account(&payer.pubkey(), &victim.pubkey(), 2 * LAMPORTS_PER_SOL, 0, &program_id);
+    let tx = Transaction::new_signed_with_payer(
+        &[create_victim_ix],
+        Some(&payer.pubkey()),
+        &[&payer, &victim],
+        svm.latest_blockhash(),
+    );
+    let res = svm.send_transaction(tx);
+    assert!(res.is_ok());
+
+    let mut data = Vec::new();
+    data.push(PROGRAM_TRANSFER_DISCRIMINATOR);
+    data.extend_from_slice(&LAMPORTS_PER_SOL.to_le_bytes());
+
+    let attack_ix = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(victim.pubkey(), false),
+            AccountMeta::new(attacker_recipient.pubkey(), false),
+        ],
+        data,
+    };
+
+    let tx =
+        Transaction::new_signed_with_payer(&[attack_ix], Some(&payer.pubkey()), &[&payer], svm.latest_blockhash());
+
+    let res = svm.send_transaction(tx);
+    assert!(res.is_err(), "expected the attacker transaction to fail");
 }

--- a/basics/transfer-sol/pinocchio/program/tests/test.rs
+++ b/basics/transfer-sol/pinocchio/program/tests/test.rs
@@ -1,10 +1,12 @@
 use litesvm::LiteSVM;
 use solana_instruction::{AccountMeta, Instruction};
+use solana_instruction_error::InstructionError;
 use solana_keypair::{Keypair, Signer};
 use solana_native_token::LAMPORTS_PER_SOL;
 use solana_pubkey::Pubkey;
 use solana_system_interface::instruction::create_account;
 use solana_transaction::Transaction;
+use solana_transaction_error::TransactionError;
 use transfer_sol_pinocchio_program::{CPI_TRANSFER_DISCRIMINATOR, PROGRAM_TRANSFER_DISCRIMINATOR};
 #[test]
 fn test_transfer_sol() {
@@ -117,5 +119,10 @@ fn test_transfer_sol() {
     let tx = Transaction::new_signed_with_payer(&[attack_ix], Some(&payer.pubkey()), &[&payer], svm.latest_blockhash());
 
     let res = svm.send_transaction(tx);
-    assert!(res.is_err(), "expected the attacker transaction to fail");
+    let err = res.expect_err("expected the attacker transaction to fail").err;
+    assert_eq!(
+        err,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature),
+        "expected the debit to be rejected for lacking the victim's signature"
+    );
 }


### PR DESCRIPTION
## Summary

Audited every `native`/`pinocchio` (non-Anchor — no macro-generated account-validation safety net) instruction handler under `basics/` for the classic Solana vulnerability classes: missing signer checks, missing owner checks before deserialization, missing PDA re-derivation, arbitrary CPI, duplicate-account aliasing. Found two real, currently-shipping vulnerabilities. Both are **invisible to the existing test suites** — every existing test only exercises the honest path (the same signer creates and later acts on their own account), so green CI gives false confidence.

This matters more here than in most repos: `program-examples` is code thousands of learners copy-paste directly into real projects, so a vulnerability in a teaching example teaches the vulnerability to everyone who copies it. Both are the textbook "missing signer authorization" pattern — the most common real-world Solana exploit class.

### 1. `basics/close-account` (native + pinocchio): anyone can close and drain anyone else's account

`close_user` / `process_close` took `target_account` and `payer`, and unconditionally moved nearly all of `target_account`'s lamports into `payer`, then reassigned it to the System Program. It never checked `payer.is_signer`, and never re-derived the `["USER", payer.key]` PDA to confirm `target_account` actually belongs to `payer`.

**Exploit:** submit `CloseUser` with `[victim's User PDA, attacker's own pubkey, System Program]`. The attacker doesn't need the victim's key at all — they sign with their own key (satisfying "some signer exists"), pass the victim's PDA as the account to close, and drain it. PDAs are discoverable via `getProgramAccounts`.

The Anchor version of this same example was already safe — `user: Signer<'info>` enforces `is_signer`, and `seeds = [b"USER", user.key().as_ref()]` on `user_account` makes Anchor auto-verify the PDA. Only the native/pinocchio ports dropped both checks when translating away from the framework.

**Fix:** require `payer.is_signer`, and re-derive + compare the expected PDA before touching `target_account`.

### 2. `basics/transfer-sol` (anchor + native + pinocchio — all three): anyone can drain any program-owned account

`transfer_sol_with_program` directly manipulates lamports (`**payer.try_borrow_mut_lamports()? -= amount`) with no CPI and no `is_signer` check anywhere. Since the Solana runtime only requires that the *owning* program initiate a lamport debit (no signature required by the runtime itself), any account owned by this program can be drained by anyone who knows its pubkey.

This is the one case where the bug is **not** an Anchor-vs-native gap — the Anchor version has it too:
```rust
/// CHECK: Use owner constraint to check account is owned by our program
#[account(mut, owner = id())]
payer: UncheckedAccount<'info>,
```
`owner = id()` confirms the account is program-owned — which the runtime requires anyway for the debit to succeed at all, so it doesn't add real protection — but never checks `is_signer`. The top-level `basics/transfer-sol/README.md` presents this as a working pattern with zero caveat about needing an authorization check, which is exactly the shape of bug that has caused real fund-loss incidents in production "vault" programs holding user funds in program-owned accounts.

**Fix:** require `payer.is_signer` in all three implementations. For Anchor, `payer` changes from `UncheckedAccount<'info>` to `Signer<'info>` (constraints like `mut`/`owner` compose with either account type, so this is a minimal, idiomatic change — not adding a redundant owner check to native/pinocchio since the runtime already refuses the debit unless the executing program owns the account).

## Test plan

Every fix ships with a new adversarial test proving the exploit is blocked. Each one was **verified to fail against the unpatched code first** (confirming it actually exercises the bug, not a false negative), then verified to pass after the fix, with every pre-existing legitimate-flow test still passing unchanged:

- [x] `close-account/native`: attacker (own signer, victim's PDA as target) — fails before fix, blocked after. 3/3 tests pass.
- [x] `close-account/pinocchio`: same attack in Rust via `cargo test` — fails before fix, blocked after. 1/1 tests pass.
- [x] `transfer-sol/anchor` (litesvm): attacker marks victim's program-owned account `isSigner: false`, only signs with their own unrelated fee-payer key — fails before fix, blocked after. 3/3 tests pass.
- [x] `transfer-sol/native`: same attack via raw `@solana/kit` account-role manipulation — fails before fix, blocked after. 4/4 tests pass.
- [x] `transfer-sol/pinocchio`: same attack via raw `AccountMeta` — fails before fix, blocked after. 1/1 tests pass. (Caught and fixed a flaw in my first draft of this test: the initial victim account had only ever *received* lamports rather than being created via `create_account`, so it was actually System-Program-owned and the runtime blocked the debit for an unrelated reason. Recreated the victim properly via `create_account` with this program as owner so the test exercises the real vulnerability.)
- [x] `transfer-sol/anchor/tests/test.ts` (the validator-based suite, not litesvm): updated the existing "Transfer SOL with Program" test to add `.signers([payerAccount])`, since `payer` is now `Signer<'info>` and must actually sign — this is a necessary, expected update to the legitimate flow, not a new issue. Could not execute this specific file locally (`solana-test-validator`/`surfpool` hangs at startup in this sandbox — unrelated to the change); the identical on-chain program logic is already fully exercised and verified via the `litesvm.test.ts` suite above, which hits the same compiled program through a full transaction-processing path.

All programs build clean (`cargo check` / `anchor build` / `cargo build-sbf`) with no new warnings beyond pre-existing ones.