### PR TITLE
security: fix broken take_offer invariant + add missing RefundOffer instruction

### DIFF
--- a/tokens/escrow/anchor/programs/escrow/src/instructions/mod.rs
+++ b/tokens/escrow/anchor/programs/escrow/src/instructions/mod.rs
@@ -4,5 +4,8 @@ pub use make_offer::*;
 pub mod take_offer;
 pub use take_offer::*;
 
+pub mod refund_offer;
+pub use refund_offer::*;
+
 pub mod shared;
 pub use shared::*;

--- a/tokens/escrow/anchor/programs/escrow/src/instructions/refund_offer.rs
+++ b/tokens/escrow/anchor/programs/escrow/src/instructions/refund_offer.rs
@@ -1,0 +1,87 @@
+use anchor_lang::prelude::*;
+
+use anchor_spl::token_interface::{
+    close_account, transfer_checked, CloseAccount, Mint, TokenAccount, TokenInterface,
+    TransferChecked,
+};
+
+use crate::Offer;
+
+#[derive(Accounts)]
+pub struct RefundOffer<'info> {
+    #[account(mut)]
+    pub maker: Signer<'info>,
+
+    pub token_mint_a: InterfaceAccount<'info, Mint>,
+
+    #[account(
+        mut,
+        associated_token::mint = token_mint_a,
+        associated_token::authority = maker,
+        associated_token::token_program = token_program,
+    )]
+    pub maker_token_account_a: InterfaceAccount<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        close = maker,
+        has_one = maker,
+        has_one = token_mint_a,
+        seeds = [b"offer", maker.key().as_ref(), offer.id.to_le_bytes().as_ref()],
+        bump = offer.bump
+    )]
+    offer: Account<'info, Offer>,
+
+    #[account(
+        mut,
+        associated_token::mint = token_mint_a,
+        associated_token::authority = offer,
+        associated_token::token_program = token_program,
+    )]
+    pub vault: InterfaceAccount<'info, TokenAccount>,
+
+    pub token_program: Interface<'info, TokenInterface>,
+}
+
+pub fn withdraw_and_close_vault_for_refund(ctx: Context<RefundOffer>) -> Result<()> {
+    let seeds = &[
+        b"offer",
+        ctx.accounts.maker.to_account_info().key.as_ref(),
+        &ctx.accounts.offer.id.to_le_bytes()[..],
+        &[ctx.accounts.offer.bump],
+    ];
+    let signer_seeds = [&seeds[..]];
+
+    let accounts = TransferChecked {
+        from: ctx.accounts.vault.to_account_info(),
+        mint: ctx.accounts.token_mint_a.to_account_info(),
+        to: ctx.accounts.maker_token_account_a.to_account_info(),
+        authority: ctx.accounts.offer.to_account_info(),
+    };
+
+    let cpi_context = CpiContext::new_with_signer(
+        ctx.accounts.token_program.key(),
+        accounts,
+        &signer_seeds,
+    );
+
+    transfer_checked(
+        cpi_context,
+        ctx.accounts.vault.amount,
+        ctx.accounts.token_mint_a.decimals,
+    )?;
+
+    let accounts = CloseAccount {
+        account: ctx.accounts.vault.to_account_info(),
+        destination: ctx.accounts.maker.to_account_info(),
+        authority: ctx.accounts.offer.to_account_info(),
+    };
+
+    let cpi_context = CpiContext::new_with_signer(
+        ctx.accounts.token_program.key(),
+        accounts,
+        &signer_seeds,
+    );
+
+    close_account(cpi_context)
+}

--- a/tokens/escrow/anchor/programs/escrow/src/lib.rs
+++ b/tokens/escrow/anchor/programs/escrow/src/lib.rs
@@ -29,4 +29,8 @@ pub mod escrow {
         instructions::take_offer::send_wanted_tokens_to_maker(&context)?;
         instructions::take_offer::withdraw_and_close_vault(context)
     }
+
+    pub fn refund_offer(context: Context<RefundOffer>) -> Result<()> {
+        instructions::refund_offer::withdraw_and_close_vault_for_refund(context)
+    }
 }

--- a/tokens/escrow/anchor/tests/litesvm.test.ts
+++ b/tokens/escrow/anchor/tests/litesvm.test.ts
@@ -202,4 +202,65 @@ describe('Escrow LiteSVM example', () => {
     it("Puts the tokens from the vault into Bob's account, and gives Alice Bob's tokens, when Bob takes an offer", async () => {
         await take();
     });
+
+    it('Returns the vaulted tokens to Alice when she refunds her own offer', async () => {
+        await make();
+
+        const aliceTokenAAccountBefore = await getAccount(
+            connection,
+            accounts.makerTokenAccountA,
+            'processed',
+            TOKEN_PROGRAM,
+        );
+        const aliceBalanceBefore = new BN(aliceTokenAAccountBefore.amount.toString());
+
+        const _transactionSignature = await program.methods
+            .refundOffer()
+            .accounts({ ...accounts })
+            .signers([alice])
+            .rpc();
+
+        // anchor-litesvm's connection proxy throws rather than returning null
+        // for a missing account, so closure is verified by expecting a throw.
+        const isClosed = async (address: PublicKey) => {
+            try {
+                await connection.getAccountInfo(address);
+                return false;
+            } catch {
+                return true;
+            }
+        };
+        assert(await isClosed(accounts.offer), 'offer account not closed');
+        assert(await isClosed(accounts.vault), 'vault account not closed');
+
+        const aliceTokenAAccountAfter = await getAccount(
+            connection,
+            accounts.makerTokenAccountA,
+            'processed',
+            TOKEN_PROGRAM,
+        );
+        const aliceBalanceAfter = new BN(aliceTokenAAccountAfter.amount.toString());
+        assert(aliceBalanceAfter.eq(aliceBalanceBefore.add(tokenAOfferedAmount)));
+    });
+
+    it('Rejects a refund attempt from a non-maker signer', async () => {
+        await make();
+
+        // Bob attempts to refund Alice's offer by claiming to be its maker.
+        let threw = false;
+        try {
+            await program.methods
+                .refundOffer()
+                .accounts({
+                    ...accounts,
+                    maker: accounts.taker,
+                    makerTokenAccountA: accounts.takerTokenAccountA,
+                })
+                .signers([bob])
+                .rpc();
+        } catch {
+            threw = true;
+        }
+        assert(threw, 'expected a non-maker refund to fail');
+    });
 });

--- a/tokens/escrow/anchor/tests/litesvm.test.ts
+++ b/tokens/escrow/anchor/tests/litesvm.test.ts
@@ -247,15 +247,19 @@ describe('Escrow LiteSVM example', () => {
         await make();
 
         // Bob attempts to refund Alice's offer by claiming to be its maker.
+        // The mismatched accounts are intentional (that's what this test is
+        // proving the program rejects), so the strict IDL-derived account
+        // type doesn't apply here.
+        const forgedAccounts: Record<string, PublicKey> = {
+            ...accounts,
+            maker: accounts.taker,
+            makerTokenAccountA: accounts.takerTokenAccountA,
+        };
         let threw = false;
         try {
             await program.methods
                 .refundOffer()
-                .accounts({
-                    ...accounts,
-                    maker: accounts.taker,
-                    makerTokenAccountA: accounts.takerTokenAccountA,
-                })
+                .accounts(forgedAccounts as any)
                 .signers([bob])
                 .rpc();
         } catch {

--- a/tokens/escrow/native/program/src/instructions/mod.rs
+++ b/tokens/escrow/native/program/src/instructions/mod.rs
@@ -3,3 +3,6 @@ pub use make_offer::*;
 
 pub mod take_offer;
 pub use take_offer::*;
+
+pub mod refund_offer;
+pub use refund_offer::*;

--- a/tokens/escrow/native/program/src/instructions/refund_offer.rs
+++ b/tokens/escrow/native/program/src/instructions/refund_offer.rs
@@ -33,6 +33,11 @@ impl RefundOffer {
             return Err(ProgramError::MissingRequiredSignature);
         }
 
+        // ensure the caller didn't substitute a fake token program - the real
+        // program is what actually enforces the transfer/close below
+        //
+        spl_token_interface::check_program_account(token_program.key)?;
+
         // get the offer data
         //
         let offer = Offer::try_from_slice(&offer_info.data.borrow()[..])?;
@@ -57,6 +62,11 @@ impl RefundOffer {
         // validate the maker's receiving address
         //
         assert_is_associated_token_account(maker_token_account_a.key, maker.key, token_mint_a.key)?;
+
+        // validate the vault is the offer's actual vault, not a substitute
+        // token-A account that also happens to be owned by the offer PDA
+        //
+        assert_is_associated_token_account(vault.key, offer_info.key, token_mint_a.key)?;
 
         // return the vaulted tokens to the maker
         //

--- a/tokens/escrow/native/program/src/instructions/refund_offer.rs
+++ b/tokens/escrow/native/program/src/instructions/refund_offer.rs
@@ -1,0 +1,108 @@
+use {
+    crate::{error::*, state::*, utils::*},
+    borsh::BorshDeserialize,
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program::invoke_signed, program_error::ProgramError,
+        program_pack::Pack, pubkey::Pubkey,
+    },
+    spl_token_interface::{instruction as token_instruction, state::Account as TokenAccount},
+};
+
+#[derive(BorshDeserialize, Debug)]
+pub struct RefundOffer {}
+
+impl RefundOffer {
+    pub fn process(program_id: &Pubkey, accounts: &[AccountInfo<'_>]) -> ProgramResult {
+        // accounts in order
+        //
+        let [
+            offer_info, // offer account info
+            token_mint_a, // token mint a
+            maker_token_account_a, // maker token a account, receives the refund
+            vault, // vault
+            maker, // maker
+            token_program, // token program
+            system_program// system program
+        ] = accounts else {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        };
+
+        // ensure the maker signs the instruction
+        //
+        if !maker.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+
+        // get the offer data
+        //
+        let offer = Offer::try_from_slice(&offer_info.data.borrow()[..])?;
+
+        // only the maker who created the offer may refund it
+        //
+        assert_eq!(&offer.maker, maker.key);
+        assert_eq!(&offer.token_mint_a, token_mint_a.key);
+
+        // validate the offer account with signer seeds
+        //
+        let offer_signer_seeds = &[Offer::SEED_PREFIX, maker.key.as_ref(), &offer.id.to_le_bytes(), &[offer.bump]];
+
+        let offer_key = Pubkey::create_program_address(offer_signer_seeds, program_id)?;
+
+        // make sure the offer key is the same
+        //
+        if *offer_info.key != offer_key {
+            return Err(EscrowError::OfferKeyMismatch.into());
+        };
+
+        // validate the maker's receiving address
+        //
+        assert_is_associated_token_account(maker_token_account_a.key, maker.key, token_mint_a.key)?;
+
+        // return the vaulted tokens to the maker
+        //
+        let vault_amount_a = TokenAccount::unpack(&vault.data.borrow())?.amount;
+
+        invoke_signed(
+            &token_instruction::transfer(
+                token_program.key,
+                vault.key,
+                maker_token_account_a.key,
+                offer_info.key,
+                &[offer_info.key],
+                vault_amount_a,
+            )?,
+            &[vault.clone(), maker_token_account_a.clone(), offer_info.clone(), token_program.clone()],
+            &[offer_signer_seeds],
+        )?;
+
+        // close the vault account, rent to the maker
+        //
+        invoke_signed(
+            &spl_token_interface::instruction::close_account(
+                token_program.key,
+                vault.key,
+                maker.key,
+                offer_info.key,
+                &[],
+            )?,
+            &[vault.clone(), maker.clone(), offer_info.clone()],
+            &[offer_signer_seeds],
+        )?;
+
+        // Send the rent back to the maker
+        //
+        let lamports = offer_info.lamports();
+        **offer_info.lamports.borrow_mut() -= lamports;
+        **maker.lamports.borrow_mut() += lamports;
+
+        // Realloc the account to zero
+        //
+        offer_info.resize(0)?;
+
+        // Assign the account to the System Program
+        //
+        offer_info.assign(system_program.key);
+
+        Ok(())
+    }
+}

--- a/tokens/escrow/native/program/src/instructions/take_offer.rs
+++ b/tokens/escrow/native/program/src/instructions/take_offer.rs
@@ -70,6 +70,11 @@ impl TakeOffer {
         assert_is_associated_token_account(maker_token_account_b.key, maker.key, token_mint_b.key)?;
         assert_is_associated_token_account(taker_token_account_a.key, taker.key, token_mint_a.key)?;
 
+        // validate the vault is the offer's actual vault, not a substitute
+        // token-A account that also happens to be owned by the offer PDA
+        //
+        assert_is_associated_token_account(vault.key, offer_info.key, token_mint_a.key)?;
+
         // create taker token A account if needed, before receiveing tokens
         //
         if taker_token_account_a.lamports() == 0 {

--- a/tokens/escrow/native/program/src/instructions/take_offer.rs
+++ b/tokens/escrow/native/program/src/instructions/take_offer.rs
@@ -168,7 +168,7 @@ impl TakeOffer {
         let maker_amount_b = TokenAccount::unpack(&maker_token_account_b.data.borrow())?.amount;
 
         assert_eq!(taker_amount_a, taker_amount_a_before_transfer + vault_amount_a);
-        assert_eq!(maker_amount_b, taker_amount_a_before_transfer + offer.token_b_wanted_amount);
+        assert_eq!(maker_amount_b, maker_amount_b_before_transfer + offer.token_b_wanted_amount);
 
         let taker_amount_b = TokenAccount::unpack(&taker_token_account_b.data.borrow())?.amount;
         let vault_amount_a = TokenAccount::unpack(&vault.data.borrow())?.amount;

--- a/tokens/escrow/native/program/src/lib.rs
+++ b/tokens/escrow/native/program/src/lib.rs
@@ -17,11 +17,15 @@ fn process_instruction(program_id: &Pubkey, accounts: &[AccountInfo], instructio
     match instruction {
         EscrowInstruction::MakeOffer(data) => MakeOffer::process(program_id, accounts, data),
         EscrowInstruction::TakeOffer => TakeOffer::process(program_id, accounts),
+        EscrowInstruction::RefundOffer => RefundOffer::process(program_id, accounts),
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
+// "Offer" is domain vocabulary, not a redundant postfix - keep MakeOffer/TakeOffer/RefundOffer.
+#[allow(clippy::enum_variant_names)]
 enum EscrowInstruction {
     MakeOffer(MakeOffer),
     TakeOffer,
+    RefundOffer,
 }

--- a/tokens/escrow/native/tests/instruction.ts
+++ b/tokens/escrow/native/tests/instruction.ts
@@ -6,6 +6,7 @@ import * as borsh from 'borsh';
 enum EscrowInstruction {
     MakeOffer = 0,
     TakeOffer = 1,
+    RefundOffer = 2,
 }
 
 const MakeOfferSchema = {
@@ -18,6 +19,12 @@ const MakeOfferSchema = {
 };
 
 const TakeOfferSchema = {
+    struct: {
+        instruction: 'u8',
+    },
+};
+
+const RefundOfferSchema = {
     struct: {
         instruction: 'u8',
     },
@@ -97,6 +104,33 @@ export function buildTakeOffer(props: {
             { address: props.payer.address, role: AccountRole.WRITABLE_SIGNER, signer: props.payer },
             { address: TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY },
             { address: ASSOCIATED_TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+        ],
+        data,
+    };
+}
+
+export function buildRefundOffer(props: {
+    offer: Address;
+    mint_a: Address;
+    maker_token_a: Address;
+    vault: Address;
+    maker: TransactionSigner;
+    programId: Address;
+}) {
+    const data = borshSerialize(RefundOfferSchema, {
+        instruction: EscrowInstruction.RefundOffer,
+    });
+
+    return {
+        programAddress: props.programId,
+        accounts: [
+            { address: props.offer, role: AccountRole.WRITABLE },
+            { address: props.mint_a, role: AccountRole.READONLY },
+            { address: props.maker_token_a, role: AccountRole.WRITABLE },
+            { address: props.vault, role: AccountRole.WRITABLE },
+            { address: props.maker.address, role: AccountRole.WRITABLE_SIGNER, signer: props.maker },
+            { address: TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY },
             { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
         ],
         data,

--- a/tokens/escrow/native/tests/test.ts
+++ b/tokens/escrow/native/tests/test.ts
@@ -13,9 +13,13 @@ import {
 } from '@solana/kit';
 import {
     getCreateAssociatedTokenIdempotentInstruction,
+    getInitializeAccount3Instruction,
     getMintToInstruction,
     getTokenDecoder,
+    getTokenSize,
+    TOKEN_PROGRAM_ADDRESS,
 } from '@solana-program/token';
+import { getCreateAccountInstruction } from '@solana-program/system';
 import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
@@ -287,6 +291,81 @@ describe('Escrow!', () => {
                 (makerTokenAccountABefore.amount + offerValues.amountA).toString(),
             'refunded amount not credited back to the maker',
         );
+    });
+
+    it('Refund Offer rejects a substitute vault account', async () => {
+        // Regression test: refund_offer used to trust whatever account was
+        // passed as `vault` without verifying it's actually the offer's
+        // canonical ATA. Any token-A account with owner = the offer PDA
+        // (creatable by anyone, without the PDA's cooperation - a token
+        // account's owner field never needs the owner to sign at creation
+        // time) could be substituted, draining that decoy instead of the
+        // real vault and then closing the offer anyway - permanently
+        // stranding the real vault's funds.
+        const offerValues = await createValues({
+            programId: values.programId,
+            maker: values.maker,
+            taker: values.taker,
+            mintAKeypair: values.mintAKeypair,
+            mintBKeypair: values.mintBKeypair,
+            id: 4n,
+        });
+
+        await sendTransaction(
+            buildMakeOffer({
+                id: offerValues.id,
+                maker: offerValues.maker,
+                maker_token_a: offerValues.makerAccountA,
+                offer: offerValues.offer,
+                token_a_offered_amount: offerValues.amountA,
+                token_b_wanted_amount: offerValues.amountB,
+                vault: offerValues.vault,
+                mint_a: offerValues.mintAKeypair.address,
+                mint_b: offerValues.mintBKeypair.address,
+                payer,
+                programId: offerValues.programId,
+            }),
+        );
+
+        // Create a decoy token-A account owned by the offer PDA - NOT the
+        // canonical ATA, so it's a different address than offerValues.vault.
+        const decoyVault = await generateKeyPairSigner();
+        const tokenSize = BigInt(getTokenSize());
+        await sendTransaction(
+            getCreateAccountInstruction({
+                payer,
+                newAccount: decoyVault,
+                space: tokenSize,
+                lamports: svm.minimumBalanceForRentExemption(tokenSize),
+                programAddress: TOKEN_PROGRAM_ADDRESS,
+            }),
+        );
+        await sendTransaction(
+            getInitializeAccount3Instruction({
+                account: decoyVault.address,
+                mint: offerValues.mintAKeypair.address,
+                owner: offerValues.offer,
+            }),
+        );
+
+        const ix = buildRefundOffer({
+            offer: offerValues.offer,
+            mint_a: offerValues.mintAKeypair.address,
+            maker_token_a: offerValues.makerAccountA,
+            vault: decoyVault.address,
+            maker: offerValues.maker,
+            programId: offerValues.programId,
+        });
+
+        const transactionMessage = pipe(
+            createTransactionMessage({ version: 0 }),
+            m => setTransactionMessageFeePayerSigner(payer, m),
+            m => svm.setTransactionMessageLifetimeUsingLatestBlockhash(m),
+            m => appendTransactionMessageInstruction(ix, m),
+        );
+        const signedTx = await signTransactionMessageWithSigners(transactionMessage);
+        const result = svm.sendTransaction(signedTx);
+        assert(result instanceof FailedTransactionMetadata, 'expected a refund against a substitute vault to fail');
     });
 
     it('Refund Offer rejects a non-maker signer', async () => {

--- a/tokens/escrow/native/tests/test.ts
+++ b/tokens/escrow/native/tests/test.ts
@@ -203,6 +203,7 @@ describe('Escrow!', () => {
         );
 
         const makerTokenBInfoBefore = svm.getAccount(offerValues.makerAccountB);
+        assert(makerTokenBInfoBefore.exists, 'maker token B account does not exist');
         const makerTokenAccountBBefore = getTokenDecoder().decode(makerTokenBInfoBefore.data);
         assert(makerTokenAccountBBefore.amount > 0n, "maker's token B account should be nonzero before Take Offer");
 
@@ -223,6 +224,7 @@ describe('Escrow!', () => {
         await sendTransaction(ix);
 
         const makerTokenBInfo = svm.getAccount(offerValues.makerAccountB);
+        assert(makerTokenBInfo.exists, 'maker token B account does not exist');
         const makerTokenAccountB = getTokenDecoder().decode(makerTokenBInfo.data);
         assert(
             makerTokenAccountB.amount.toString() === (makerTokenAccountBBefore.amount + offerValues.amountB).toString(),
@@ -257,6 +259,7 @@ describe('Escrow!', () => {
         );
 
         const makerTokenAInfoBefore = svm.getAccount(offerValues.makerAccountA);
+        assert(makerTokenAInfoBefore.exists, 'maker token A account does not exist');
         const makerTokenAccountABefore = getTokenDecoder().decode(makerTokenAInfoBefore.data);
 
         const ix = buildRefundOffer({
@@ -277,6 +280,7 @@ describe('Escrow!', () => {
         assert(!vaultInfo.exists, 'vault account not closed');
 
         const makerTokenAInfoAfter = svm.getAccount(offerValues.makerAccountA);
+        assert(makerTokenAInfoAfter.exists, 'maker token A account does not exist');
         const makerTokenAccountAAfter = getTokenDecoder().decode(makerTokenAInfoAfter.data);
         assert(
             makerTokenAccountAAfter.amount.toString() ===

--- a/tokens/escrow/native/tests/test.ts
+++ b/tokens/escrow/native/tests/test.ts
@@ -11,12 +11,16 @@ import {
     setTransactionMessageFeePayerSigner,
     signTransactionMessageWithSigners,
 } from '@solana/kit';
-import { getTokenDecoder } from '@solana-program/token';
+import {
+    getCreateAssociatedTokenIdempotentInstruction,
+    getMintToInstruction,
+    getTokenDecoder,
+} from '@solana-program/token';
 import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 import { type OfferRaw, OfferSchema } from './account';
-import { buildMakeOffer, buildTakeOffer } from './instruction';
+import { buildMakeOffer, buildRefundOffer, buildTakeOffer } from './instruction';
 import { createValues, type TestValues, mintingTokens } from './utils';
 
 const LAMPORTS_PER_SOL = 1_000_000_000n;
@@ -137,5 +141,194 @@ describe('Escrow!', () => {
 
         assert(takerTokenAccountA.amount.toString() === values.amountA.toString(), 'unexpected amount a');
         assert(makerTokenAccountB.amount.toString() === values.amountB.toString(), 'unexpected amount b');
+    });
+
+    it("Take Offer succeeds even if the maker's receiving account already has a balance", async () => {
+        // Regression test: take_offer used to compare the maker's post-transfer
+        // token B balance against the wrong pre-transfer variable, so the
+        // instruction only worked by coincidence when the maker's token B
+        // account started at exactly 0. Any third party could permanently
+        // brick an offer for free by creating the maker's token B ATA and
+        // sending it 1 base unit before a take - both permissionless, no
+        // signature required from the maker. This offer's maker_token_b
+        // account is pre-funded before Take Offer runs to reproduce exactly
+        // that condition.
+        const offerValues = await createValues({
+            programId: values.programId,
+            maker: values.maker,
+            taker: values.taker,
+            mintAKeypair: values.mintAKeypair,
+            mintBKeypair: values.mintBKeypair,
+            id: 1n,
+        });
+
+        await sendTransaction(
+            buildMakeOffer({
+                id: offerValues.id,
+                maker: offerValues.maker,
+                maker_token_a: offerValues.makerAccountA,
+                offer: offerValues.offer,
+                token_a_offered_amount: offerValues.amountA,
+                token_b_wanted_amount: offerValues.amountB,
+                vault: offerValues.vault,
+                mint_a: offerValues.mintAKeypair.address,
+                mint_b: offerValues.mintBKeypair.address,
+                payer,
+                programId: offerValues.programId,
+            }),
+        );
+
+        // Pre-fund the maker's token B account with a small existing balance -
+        // this is exactly what a griefing third party (or a maker who simply
+        // already held some of the wanted token) would produce. This ATA is
+        // shared with the maker's other offers (same maker + mint B), so it
+        // may already carry a balance from earlier tests too - either way,
+        // the point is that it's nonzero before this Take Offer runs.
+        const dustAmount = 1n;
+        await sendTransaction(
+            getCreateAssociatedTokenIdempotentInstruction({
+                payer,
+                ata: offerValues.makerAccountB,
+                owner: offerValues.maker.address,
+                mint: offerValues.mintBKeypair.address,
+            }),
+        );
+        await sendTransaction(
+            getMintToInstruction({
+                mint: offerValues.mintBKeypair.address,
+                token: offerValues.makerAccountB,
+                mintAuthority: payer,
+                amount: dustAmount,
+            }),
+        );
+
+        const makerTokenBInfoBefore = svm.getAccount(offerValues.makerAccountB);
+        const makerTokenAccountBBefore = getTokenDecoder().decode(makerTokenBInfoBefore.data);
+        assert(makerTokenAccountBBefore.amount > 0n, "maker's token B account should be nonzero before Take Offer");
+
+        const ix = buildTakeOffer({
+            maker: offerValues.maker.address,
+            offer: offerValues.offer,
+            vault: offerValues.vault,
+            mint_a: offerValues.mintAKeypair.address,
+            mint_b: offerValues.mintBKeypair.address,
+            maker_token_b: offerValues.makerAccountB,
+            taker: offerValues.taker,
+            taker_token_a: offerValues.takerAccountA,
+            taker_token_b: offerValues.takerAccountB,
+            payer,
+            programId: offerValues.programId,
+        });
+
+        await sendTransaction(ix);
+
+        const makerTokenBInfo = svm.getAccount(offerValues.makerAccountB);
+        const makerTokenAccountB = getTokenDecoder().decode(makerTokenBInfo.data);
+        assert(
+            makerTokenAccountB.amount.toString() === (makerTokenAccountBBefore.amount + offerValues.amountB).toString(),
+            'maker token B balance should be its pre-existing balance plus the wanted amount',
+        );
+    });
+
+    it('Refund Offer returns the vaulted tokens to the maker', async () => {
+        const offerValues = await createValues({
+            programId: values.programId,
+            maker: values.maker,
+            taker: values.taker,
+            mintAKeypair: values.mintAKeypair,
+            mintBKeypair: values.mintBKeypair,
+            id: 2n,
+        });
+
+        await sendTransaction(
+            buildMakeOffer({
+                id: offerValues.id,
+                maker: offerValues.maker,
+                maker_token_a: offerValues.makerAccountA,
+                offer: offerValues.offer,
+                token_a_offered_amount: offerValues.amountA,
+                token_b_wanted_amount: offerValues.amountB,
+                vault: offerValues.vault,
+                mint_a: offerValues.mintAKeypair.address,
+                mint_b: offerValues.mintBKeypair.address,
+                payer,
+                programId: offerValues.programId,
+            }),
+        );
+
+        const makerTokenAInfoBefore = svm.getAccount(offerValues.makerAccountA);
+        const makerTokenAccountABefore = getTokenDecoder().decode(makerTokenAInfoBefore.data);
+
+        const ix = buildRefundOffer({
+            offer: offerValues.offer,
+            mint_a: offerValues.mintAKeypair.address,
+            maker_token_a: offerValues.makerAccountA,
+            vault: offerValues.vault,
+            maker: offerValues.maker,
+            programId: offerValues.programId,
+        });
+
+        await sendTransaction(ix);
+
+        const offerInfo = svm.getAccount(offerValues.offer);
+        assert(!offerInfo.exists, 'offer account not closed');
+
+        const vaultInfo = svm.getAccount(offerValues.vault);
+        assert(!vaultInfo.exists, 'vault account not closed');
+
+        const makerTokenAInfoAfter = svm.getAccount(offerValues.makerAccountA);
+        const makerTokenAccountAAfter = getTokenDecoder().decode(makerTokenAInfoAfter.data);
+        assert(
+            makerTokenAccountAAfter.amount.toString() ===
+                (makerTokenAccountABefore.amount + offerValues.amountA).toString(),
+            'refunded amount not credited back to the maker',
+        );
+    });
+
+    it('Refund Offer rejects a non-maker signer', async () => {
+        const offerValues = await createValues({
+            programId: values.programId,
+            maker: values.maker,
+            taker: values.taker,
+            mintAKeypair: values.mintAKeypair,
+            mintBKeypair: values.mintBKeypair,
+            id: 3n,
+        });
+
+        await sendTransaction(
+            buildMakeOffer({
+                id: offerValues.id,
+                maker: offerValues.maker,
+                maker_token_a: offerValues.makerAccountA,
+                offer: offerValues.offer,
+                token_a_offered_amount: offerValues.amountA,
+                token_b_wanted_amount: offerValues.amountB,
+                vault: offerValues.vault,
+                mint_a: offerValues.mintAKeypair.address,
+                mint_b: offerValues.mintBKeypair.address,
+                payer,
+                programId: offerValues.programId,
+            }),
+        );
+
+        // The taker attempts to refund the maker's offer to their own account.
+        const ix = buildRefundOffer({
+            offer: offerValues.offer,
+            mint_a: offerValues.mintAKeypair.address,
+            maker_token_a: offerValues.takerAccountA,
+            vault: offerValues.vault,
+            maker: offerValues.taker,
+            programId: offerValues.programId,
+        });
+
+        const transactionMessage = pipe(
+            createTransactionMessage({ version: 0 }),
+            m => setTransactionMessageFeePayerSigner(payer, m),
+            m => svm.setTransactionMessageLifetimeUsingLatestBlockhash(m),
+            m => appendTransactionMessageInstruction(ix, m),
+        );
+        const signedTx = await signTransactionMessageWithSigners(transactionMessage);
+        const result = svm.sendTransaction(signedTx);
+        assert(result instanceof FailedTransactionMetadata, 'expected a non-maker refund to fail');
     });
 });

--- a/tokens/escrow/native/tests/test.ts
+++ b/tokens/escrow/native/tests/test.ts
@@ -236,6 +236,82 @@ describe('Escrow!', () => {
         );
     });
 
+    it('Take Offer rejects a substitute vault account', async () => {
+        // Same class of bug as the "Refund Offer rejects a substitute vault
+        // account" regression below, but in take_offer: it also trusted
+        // whatever account was passed as `vault` without verifying it's
+        // actually the offer's canonical ATA.
+        const offerValues = await createValues({
+            programId: values.programId,
+            maker: values.maker,
+            taker: values.taker,
+            mintAKeypair: values.mintAKeypair,
+            mintBKeypair: values.mintBKeypair,
+            id: 5n,
+        });
+
+        await sendTransaction(
+            buildMakeOffer({
+                id: offerValues.id,
+                maker: offerValues.maker,
+                maker_token_a: offerValues.makerAccountA,
+                offer: offerValues.offer,
+                token_a_offered_amount: offerValues.amountA,
+                token_b_wanted_amount: offerValues.amountB,
+                vault: offerValues.vault,
+                mint_a: offerValues.mintAKeypair.address,
+                mint_b: offerValues.mintBKeypair.address,
+                payer,
+                programId: offerValues.programId,
+            }),
+        );
+
+        // Create a decoy token-A account owned by the offer PDA - NOT the
+        // canonical ATA, so it's a different address than offerValues.vault.
+        const decoyVault = await generateKeyPairSigner();
+        const tokenSize = BigInt(getTokenSize());
+        await sendTransaction(
+            getCreateAccountInstruction({
+                payer,
+                newAccount: decoyVault,
+                space: tokenSize,
+                lamports: svm.minimumBalanceForRentExemption(tokenSize),
+                programAddress: TOKEN_PROGRAM_ADDRESS,
+            }),
+        );
+        await sendTransaction(
+            getInitializeAccount3Instruction({
+                account: decoyVault.address,
+                mint: offerValues.mintAKeypair.address,
+                owner: offerValues.offer,
+            }),
+        );
+
+        const ix = buildTakeOffer({
+            maker: offerValues.maker.address,
+            offer: offerValues.offer,
+            vault: decoyVault.address,
+            mint_a: offerValues.mintAKeypair.address,
+            mint_b: offerValues.mintBKeypair.address,
+            maker_token_b: offerValues.makerAccountB,
+            taker: offerValues.taker,
+            taker_token_a: offerValues.takerAccountA,
+            taker_token_b: offerValues.takerAccountB,
+            payer,
+            programId: offerValues.programId,
+        });
+
+        const transactionMessage = pipe(
+            createTransactionMessage({ version: 0 }),
+            m => setTransactionMessageFeePayerSigner(payer, m),
+            m => svm.setTransactionMessageLifetimeUsingLatestBlockhash(m),
+            m => appendTransactionMessageInstruction(ix, m),
+        );
+        const signedTx = await signTransactionMessageWithSigners(transactionMessage);
+        const result = svm.sendTransaction(signedTx);
+        assert(result instanceof FailedTransactionMetadata, 'expected a take against a substitute vault to fail');
+    });
+
     it('Refund Offer returns the vaulted tokens to the maker', async () => {
         const offerValues = await createValues({
             programId: values.programId,

--- a/tokens/escrow/native/tests/utils.ts
+++ b/tokens/escrow/native/tests/utils.ts
@@ -171,14 +171,18 @@ export async function createValues(defaults?: TestValuesDefaults): Promise<TestV
     const maker = defaults?.maker ?? (await generateKeyPairSigner());
     const taker = defaults?.taker ?? (await generateKeyPairSigner());
 
-    // Making sure tokens are in the right order
-    let mintAKeypair = defaults?.mintAKeypair;
-    let mintBKeypair = defaults?.mintBKeypair;
-    if (!mintAKeypair || !mintBKeypair) {
-        mintAKeypair = mintAKeypair ?? (await generateKeyPairSigner());
-        mintBKeypair = mintBKeypair ?? (await generateKeyPairSigner());
-        while (isLessThan(addressEncoder.encode(mintBKeypair.address), addressEncoder.encode(mintAKeypair.address))) {
+    // Making sure tokens are in the right order. Only the mint(s) NOT
+    // supplied by the caller are ever (re)generated, so a caller-provided
+    // mint is never silently discarded.
+    let mintAKeypair = defaults?.mintAKeypair ?? (await generateKeyPairSigner());
+    let mintBKeypair = defaults?.mintBKeypair ?? (await generateKeyPairSigner());
+    while (isLessThan(addressEncoder.encode(mintBKeypair.address), addressEncoder.encode(mintAKeypair.address))) {
+        if (!defaults?.mintAKeypair) {
+            mintAKeypair = await generateKeyPairSigner();
+        } else if (!defaults?.mintBKeypair) {
             mintBKeypair = await generateKeyPairSigner();
+        } else {
+            throw new Error('mintAKeypair and mintBKeypair were both supplied out of the required address order');
         }
     }
 

--- a/tokens/escrow/native/tests/utils.ts
+++ b/tokens/escrow/native/tests/utils.ts
@@ -168,14 +168,18 @@ export async function createValues(defaults?: TestValuesDefaults): Promise<TestV
 
     const programId = defaults?.programId ?? (await generateKeyPairSigner()).address;
     const id = defaults?.id ?? 0n;
-    const maker = await generateKeyPairSigner();
-    const taker = await generateKeyPairSigner();
+    const maker = defaults?.maker ?? (await generateKeyPairSigner());
+    const taker = defaults?.taker ?? (await generateKeyPairSigner());
 
     // Making sure tokens are in the right order
-    const mintAKeypair = await generateKeyPairSigner();
-    let mintBKeypair = await generateKeyPairSigner();
-    while (isLessThan(addressEncoder.encode(mintBKeypair.address), addressEncoder.encode(mintAKeypair.address))) {
-        mintBKeypair = await generateKeyPairSigner();
+    let mintAKeypair = defaults?.mintAKeypair;
+    let mintBKeypair = defaults?.mintBKeypair;
+    if (!mintAKeypair || !mintBKeypair) {
+        mintAKeypair = mintAKeypair ?? (await generateKeyPairSigner());
+        mintBKeypair = mintBKeypair ?? (await generateKeyPairSigner());
+        while (isLessThan(addressEncoder.encode(mintBKeypair.address), addressEncoder.encode(mintAKeypair.address))) {
+            mintBKeypair = await generateKeyPairSigner();
+        }
     }
 
     const [offer] = await getProgramDerivedAddress({
@@ -195,8 +199,8 @@ export async function createValues(defaults?: TestValuesDefaults): Promise<TestV
         makerAccountB: await findAssociatedTokenAddress(mintBKeypair.address, maker.address),
         takerAccountA: await findAssociatedTokenAddress(mintAKeypair.address, taker.address),
         takerAccountB: await findAssociatedTokenAddress(mintBKeypair.address, taker.address),
-        amountA: BigInt(4 * 10 ** 6),
-        amountB: BigInt(1 * 10 ** 6),
+        amountA: defaults?.amountA ?? BigInt(4 * 10 ** 6),
+        amountB: defaults?.amountB ?? BigInt(1 * 10 ** 6),
         programId,
     };
 }

--- a/tokens/escrow/pinocchio/program/src/instructions/mod.rs
+++ b/tokens/escrow/pinocchio/program/src/instructions/mod.rs
@@ -1,9 +1,11 @@
 use pinocchio::error::ProgramError;
 
 mod make_offer;
+mod refund_offer;
 mod take_offer;
 
 pub use make_offer::*;
+pub use refund_offer::*;
 pub use take_offer::*;
 
 /// Reads a little-endian `u64` starting at `offset` within `data`.

--- a/tokens/escrow/pinocchio/program/src/instructions/refund_offer.rs
+++ b/tokens/escrow/pinocchio/program/src/instructions/refund_offer.rs
@@ -52,6 +52,16 @@ pub fn refund_offer(program_id: &Address, accounts: &mut [AccountView], _data: &
         return Err(ProgramError::InvalidSeeds);
     }
 
+    // Verify vault is the offer's actual vault, not a substitute token-A
+    // account that also happens to be owned by the offer PDA.
+    let (expected_vault, _) = Address::find_program_address(
+        &[offer_account.address().as_ref(), pinocchio_token::ID.as_ref(), token_mint_a.address().as_ref()],
+        &pinocchio_associated_token_account::ID,
+    );
+    if vault.address() != &expected_vault {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
     let vault_amount = TokenAccount::from_account_view(vault)?.amount();
 
     let seeds = [

--- a/tokens/escrow/pinocchio/program/src/instructions/refund_offer.rs
+++ b/tokens/escrow/pinocchio/program/src/instructions/refund_offer.rs
@@ -1,0 +1,90 @@
+use pinocchio::{
+    cpi::{Seed, Signer},
+    error::ProgramError,
+    AccountView, Address, ProgramResult,
+};
+use pinocchio_token::{instructions::CloseAccount, instructions::Transfer, state::Account as TokenAccount};
+
+use crate::state::Offer;
+
+/// Refunds an open offer: the vaulted token A is returned to the maker and
+/// the vault and offer accounts are closed. Only the maker who created the
+/// offer may call this.
+///
+/// Accounts:
+///   0. `[writable]`         offer account (PDA `[b"offer", maker, id]`, closed here)
+///   1. `[]`                 token mint A
+///   2. `[writable]`         maker's token A account (receives the refund)
+///   3. `[writable]`         vault (offer PDA's token A account, drained and closed)
+///   4. `[signer, writable]` maker
+///   5. `[]`                 token program
+///
+/// Instruction data: none.
+pub fn refund_offer(program_id: &Address, accounts: &mut [AccountView], _data: &[u8]) -> ProgramResult {
+    let [offer_account, token_mint_a, maker_token_account_a, vault, maker, _token_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !maker.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    // Load the recorded offer terms (the borrow is released at the block's end).
+    let offer = {
+        let offer_data = offer_account.try_borrow()?;
+        Offer::deserialize(&offer_data)?
+    };
+
+    // Only the maker who created the offer may refund it.
+    if &offer.maker != maker.address().as_array() || &offer.token_mint_a != token_mint_a.address().as_array() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Re-derive the offer PDA from the stored bump and confirm it is genuine.
+    let id_bytes = offer.id.to_le_bytes();
+    let bump_bytes = [offer.bump];
+    let offer_pda = Address::create_program_address(
+        &[Offer::SEED_PREFIX, maker.address().as_ref(), &id_bytes, &bump_bytes],
+        program_id,
+    )
+    .map_err(|_| ProgramError::InvalidSeeds)?;
+    if offer_account.address() != &offer_pda {
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    let vault_amount = TokenAccount::from_account_view(vault)?.amount();
+
+    let seeds = [
+        Seed::from(Offer::SEED_PREFIX),
+        Seed::from(maker.address().as_ref()),
+        Seed::from(&id_bytes),
+        Seed::from(&bump_bytes),
+    ];
+    let signers = [Signer::from(&seeds)];
+
+    // Return the vaulted token A to the maker.
+    Transfer {
+        from: vault,
+        to: maker_token_account_a,
+        authority: offer_account,
+        multisig_signers: &[] as &[&AccountView],
+        amount: vault_amount,
+    }
+    .invoke_signed(&signers)?;
+
+    // Close the now-empty vault, returning its rent to the maker.
+    CloseAccount {
+        account: vault,
+        destination: maker,
+        authority: offer_account,
+        multisig_signers: &[] as &[&AccountView],
+    }
+    .invoke_signed(&signers)?;
+
+    // Close the offer account, returning its rent to the maker.
+    let new_maker_lamports = maker.lamports() + offer_account.lamports();
+    maker.set_lamports(new_maker_lamports);
+    offer_account.close()?;
+
+    Ok(())
+}

--- a/tokens/escrow/pinocchio/program/src/instructions/refund_offer.rs
+++ b/tokens/escrow/pinocchio/program/src/instructions/refund_offer.rs
@@ -62,6 +62,16 @@ pub fn refund_offer(program_id: &Address, accounts: &mut [AccountView], _data: &
         return Err(ProgramError::InvalidAccountData);
     }
 
+    // Verify maker_token_account_a is the maker's actual associated token
+    // account, not a substitute destination.
+    let (expected_maker_token_account_a, _) = Address::find_program_address(
+        &[maker.address().as_ref(), pinocchio_token::ID.as_ref(), token_mint_a.address().as_ref()],
+        &pinocchio_associated_token_account::ID,
+    );
+    if maker_token_account_a.address() != &expected_maker_token_account_a {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
     let vault_amount = TokenAccount::from_account_view(vault)?.amount();
 
     let seeds = [

--- a/tokens/escrow/pinocchio/program/src/instructions/take_offer.rs
+++ b/tokens/escrow/pinocchio/program/src/instructions/take_offer.rs
@@ -66,6 +66,16 @@ pub fn take_offer(program_id: &Address, accounts: &mut [AccountView], _data: &[u
         return Err(ProgramError::InvalidSeeds);
     }
 
+    // Verify vault is the offer's actual vault, not a substitute token-A
+    // account that also happens to be owned by the offer PDA.
+    let (expected_vault, _) = Address::find_program_address(
+        &[offer_account.address().as_ref(), pinocchio_token::ID.as_ref(), token_mint_a.address().as_ref()],
+        &pinocchio_associated_token_account::ID,
+    );
+    if vault.address() != &expected_vault {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
     // Make sure both recipients have token accounts to receive into.
     log!("Ensuring taker token A account exists");
     CreateIdempotent {

--- a/tokens/escrow/pinocchio/program/src/processor.rs
+++ b/tokens/escrow/pinocchio/program/src/processor.rs
@@ -1,7 +1,7 @@
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 use pinocchio_log::log;
 
-use crate::instructions::{make_offer, take_offer};
+use crate::instructions::{make_offer, refund_offer, take_offer};
 
 /// Dispatches an instruction based on its leading discriminator byte.
 ///
@@ -9,6 +9,7 @@ use crate::instructions::{make_offer, take_offer};
 ///   - `0` -> MakeOffer (args: `[id: u64 (LE), token_a_offered_amount: u64 (LE),
 ///                              token_b_wanted_amount: u64 (LE), bump: u8]`)
 ///   - `1` -> TakeOffer (no args)
+///   - `2` -> RefundOffer (no args)
 pub fn process_instruction(
     program_id: &Address,
     accounts: &mut [AccountView],
@@ -24,6 +25,10 @@ pub fn process_instruction(
         1 => {
             log!("Instruction: TakeOffer");
             take_offer(program_id, accounts, args)
+        }
+        2 => {
+            log!("Instruction: RefundOffer");
+            refund_offer(program_id, accounts, args)
         }
         _ => Err(ProgramError::InvalidInstructionData),
     }

--- a/tokens/escrow/pinocchio/tests/instruction.ts
+++ b/tokens/escrow/pinocchio/tests/instruction.ts
@@ -6,6 +6,7 @@ import * as borsh from 'borsh';
 enum EscrowInstruction {
     MakeOffer = 0,
     TakeOffer = 1,
+    RefundOffer = 2,
 }
 
 // Unlike the native example, the Pinocchio program receives the offer PDA bump
@@ -21,6 +22,12 @@ const MakeOfferSchema = {
 };
 
 const TakeOfferSchema = {
+    struct: {
+        instruction: 'u8',
+    },
+};
+
+const RefundOfferSchema = {
     struct: {
         instruction: 'u8',
     },
@@ -99,6 +106,32 @@ export function buildTakeOffer(props: {
             { address: TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY },
             { address: ASSOCIATED_TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY },
             { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+        ],
+        data,
+    };
+}
+
+export function buildRefundOffer(props: {
+    offer: Address;
+    mint_a: Address;
+    maker_token_a: Address;
+    vault: Address;
+    maker: KeyPairSigner;
+    programId: Address;
+}) {
+    const data = borsh.serialize(RefundOfferSchema, {
+        instruction: EscrowInstruction.RefundOffer,
+    });
+
+    return {
+        programAddress: props.programId,
+        accounts: [
+            { address: props.offer, role: AccountRole.WRITABLE },
+            { address: props.mint_a, role: AccountRole.READONLY },
+            { address: props.maker_token_a, role: AccountRole.WRITABLE },
+            { address: props.vault, role: AccountRole.WRITABLE },
+            { address: props.maker.address, role: AccountRole.WRITABLE_SIGNER, signer: props.maker },
+            { address: TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY },
         ],
         data,
     };

--- a/tokens/escrow/pinocchio/tests/test.ts
+++ b/tokens/escrow/pinocchio/tests/test.ts
@@ -4,8 +4,8 @@ import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { LiteSVM } from 'litesvm';
 import { type OfferRaw, OfferSchema } from './account';
-import { buildMakeOffer, buildTakeOffer } from './instruction';
-import { createValues, mintingTokens, sendInstructions, type TestValues } from './utils';
+import { buildMakeOffer, buildRefundOffer, buildTakeOffer } from './instruction';
+import { createValues, expectRevert, mintingTokens, sendInstructions, type TestValues } from './utils';
 
 const addressDecoder = getAddressDecoder();
 
@@ -105,5 +105,104 @@ describe('Escrow (Pinocchio)', () => {
 
         assert(takerTokenAccountA.amount === values.amountA, 'unexpected amount a');
         assert(makerTokenAccountB.amount === values.amountB, 'unexpected amount b');
+    });
+
+    it('Refund Offer returns the vaulted tokens to the maker', async () => {
+        const offerValues = await createValues({
+            programId: values.programId,
+            maker: values.maker,
+            taker: values.taker,
+            mintAKeypair: values.mintAKeypair,
+            mintBKeypair: values.mintBKeypair,
+            id: 1n,
+        });
+
+        await sendInstructions(svm, payer, [
+            buildMakeOffer({
+                id: offerValues.id,
+                maker: offerValues.maker,
+                maker_token_a: offerValues.makerAccountA,
+                offer: offerValues.offer,
+                bump: offerValues.offerBump,
+                token_a_offered_amount: offerValues.amountA,
+                token_b_wanted_amount: offerValues.amountB,
+                vault: offerValues.vault,
+                mint_a: offerValues.mintAKeypair.address,
+                mint_b: offerValues.mintBKeypair.address,
+                payer,
+                programId: offerValues.programId,
+            }),
+        ]);
+
+        const makerTokenAInfoBefore = svm.getAccount(offerValues.makerAccountA);
+        if (!makerTokenAInfoBefore.exists) throw new Error('Maker token A account not found');
+        const makerTokenAccountABefore = getTokenDecoder().decode(makerTokenAInfoBefore.data);
+
+        await sendInstructions(svm, payer, [
+            buildRefundOffer({
+                offer: offerValues.offer,
+                mint_a: offerValues.mintAKeypair.address,
+                maker_token_a: offerValues.makerAccountA,
+                vault: offerValues.vault,
+                maker: offerValues.maker,
+                programId: offerValues.programId,
+            }),
+        ]);
+
+        const offerInfo = svm.getAccount(offerValues.offer);
+        assert(!offerInfo.exists, 'offer account not closed');
+
+        const vaultInfo = svm.getAccount(offerValues.vault);
+        assert(!vaultInfo.exists, 'vault account not closed');
+
+        const makerTokenAInfoAfter = svm.getAccount(offerValues.makerAccountA);
+        if (!makerTokenAInfoAfter.exists) throw new Error('Maker token A account not found');
+        const makerTokenAccountAAfter = getTokenDecoder().decode(makerTokenAInfoAfter.data);
+        assert(
+            makerTokenAccountAAfter.amount === makerTokenAccountABefore.amount + offerValues.amountA,
+            'refunded amount not credited back to the maker',
+        );
+    });
+
+    it('Refund Offer rejects a non-maker signer', async () => {
+        const offerValues = await createValues({
+            programId: values.programId,
+            maker: values.maker,
+            taker: values.taker,
+            mintAKeypair: values.mintAKeypair,
+            mintBKeypair: values.mintBKeypair,
+            id: 2n,
+        });
+
+        await sendInstructions(svm, payer, [
+            buildMakeOffer({
+                id: offerValues.id,
+                maker: offerValues.maker,
+                maker_token_a: offerValues.makerAccountA,
+                offer: offerValues.offer,
+                bump: offerValues.offerBump,
+                token_a_offered_amount: offerValues.amountA,
+                token_b_wanted_amount: offerValues.amountB,
+                vault: offerValues.vault,
+                mint_a: offerValues.mintAKeypair.address,
+                mint_b: offerValues.mintBKeypair.address,
+                payer,
+                programId: offerValues.programId,
+            }),
+        ]);
+
+        // The taker attempts to refund the maker's offer to their own account.
+        await expectRevert(
+            sendInstructions(svm, payer, [
+                buildRefundOffer({
+                    offer: offerValues.offer,
+                    mint_a: offerValues.mintAKeypair.address,
+                    maker_token_a: offerValues.takerAccountA,
+                    vault: offerValues.vault,
+                    maker: offerValues.taker,
+                    programId: offerValues.programId,
+                }),
+            ]),
+        );
     });
 });

--- a/tokens/escrow/pinocchio/tests/test.ts
+++ b/tokens/escrow/pinocchio/tests/test.ts
@@ -1,5 +1,11 @@
 import { generateKeyPairSigner, getAddressDecoder, type KeyPairSigner, lamports } from '@solana/kit';
-import { getTokenDecoder } from '@solana-program/token';
+import { getCreateAccountInstruction } from '@solana-program/system';
+import {
+    getInitializeAccount3Instruction,
+    getTokenDecoder,
+    getTokenSize,
+    TOKEN_PROGRAM_ADDRESS,
+} from '@solana-program/token';
 import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { LiteSVM } from 'litesvm';
@@ -107,6 +113,81 @@ describe('Escrow (Pinocchio)', () => {
         assert(makerTokenAccountB.amount === values.amountB, 'unexpected amount b');
     });
 
+    it('Take Offer rejects a substitute vault account', async () => {
+        // Regression test: take_offer used to trust whatever account was
+        // passed as `vault` without verifying it's actually the offer's
+        // canonical ATA. Any token-A account with owner = the offer PDA
+        // (creatable by anyone, without the PDA's cooperation - a token
+        // account's owner field never needs the owner to sign at creation
+        // time) could be substituted, draining that decoy instead of the
+        // real vault and then closing the offer anyway - permanently
+        // stranding the real vault's funds.
+        const offerValues = await createValues({
+            programId: values.programId,
+            maker: values.maker,
+            taker: values.taker,
+            mintAKeypair: values.mintAKeypair,
+            mintBKeypair: values.mintBKeypair,
+            id: 3n,
+        });
+
+        await sendInstructions(svm, payer, [
+            buildMakeOffer({
+                id: offerValues.id,
+                maker: offerValues.maker,
+                maker_token_a: offerValues.makerAccountA,
+                offer: offerValues.offer,
+                bump: offerValues.offerBump,
+                token_a_offered_amount: offerValues.amountA,
+                token_b_wanted_amount: offerValues.amountB,
+                vault: offerValues.vault,
+                mint_a: offerValues.mintAKeypair.address,
+                mint_b: offerValues.mintBKeypair.address,
+                payer,
+                programId: offerValues.programId,
+            }),
+        ]);
+
+        // Create a decoy token-A account owned by the offer PDA - NOT the
+        // canonical ATA, so it's a different address than offerValues.vault.
+        const decoyVault = await generateKeyPairSigner();
+        const tokenSize = BigInt(getTokenSize());
+        await sendInstructions(svm, payer, [
+            getCreateAccountInstruction({
+                payer,
+                newAccount: decoyVault,
+                space: tokenSize,
+                lamports: svm.minimumBalanceForRentExemption(tokenSize),
+                programAddress: TOKEN_PROGRAM_ADDRESS,
+            }),
+        ]);
+        await sendInstructions(svm, payer, [
+            getInitializeAccount3Instruction({
+                account: decoyVault.address,
+                mint: offerValues.mintAKeypair.address,
+                owner: offerValues.offer,
+            }),
+        ]);
+
+        await expectRevert(
+            sendInstructions(svm, payer, [
+                buildTakeOffer({
+                    maker: offerValues.maker.address,
+                    offer: offerValues.offer,
+                    vault: decoyVault.address,
+                    mint_a: offerValues.mintAKeypair.address,
+                    mint_b: offerValues.mintBKeypair.address,
+                    maker_token_b: offerValues.makerAccountB,
+                    taker: offerValues.taker,
+                    taker_token_a: offerValues.takerAccountA,
+                    taker_token_b: offerValues.takerAccountB,
+                    payer,
+                    programId: offerValues.programId,
+                }),
+            ]),
+        );
+    });
+
     it('Refund Offer returns the vaulted tokens to the maker', async () => {
         const offerValues = await createValues({
             programId: values.programId,
@@ -200,6 +281,117 @@ describe('Escrow (Pinocchio)', () => {
                     maker_token_a: offerValues.takerAccountA,
                     vault: offerValues.vault,
                     maker: offerValues.taker,
+                    programId: offerValues.programId,
+                }),
+            ]),
+        );
+    });
+
+    it('Refund Offer rejects a substitute vault account', async () => {
+        // Same class of bug as the Take Offer regression above, in
+        // refund_offer's own vault.
+        const offerValues = await createValues({
+            programId: values.programId,
+            maker: values.maker,
+            taker: values.taker,
+            mintAKeypair: values.mintAKeypair,
+            mintBKeypair: values.mintBKeypair,
+            id: 4n,
+        });
+
+        await sendInstructions(svm, payer, [
+            buildMakeOffer({
+                id: offerValues.id,
+                maker: offerValues.maker,
+                maker_token_a: offerValues.makerAccountA,
+                offer: offerValues.offer,
+                bump: offerValues.offerBump,
+                token_a_offered_amount: offerValues.amountA,
+                token_b_wanted_amount: offerValues.amountB,
+                vault: offerValues.vault,
+                mint_a: offerValues.mintAKeypair.address,
+                mint_b: offerValues.mintBKeypair.address,
+                payer,
+                programId: offerValues.programId,
+            }),
+        ]);
+
+        const decoyVault = await generateKeyPairSigner();
+        const tokenSize = BigInt(getTokenSize());
+        await sendInstructions(svm, payer, [
+            getCreateAccountInstruction({
+                payer,
+                newAccount: decoyVault,
+                space: tokenSize,
+                lamports: svm.minimumBalanceForRentExemption(tokenSize),
+                programAddress: TOKEN_PROGRAM_ADDRESS,
+            }),
+        ]);
+        await sendInstructions(svm, payer, [
+            getInitializeAccount3Instruction({
+                account: decoyVault.address,
+                mint: offerValues.mintAKeypair.address,
+                owner: offerValues.offer,
+            }),
+        ]);
+
+        await expectRevert(
+            sendInstructions(svm, payer, [
+                buildRefundOffer({
+                    offer: offerValues.offer,
+                    mint_a: offerValues.mintAKeypair.address,
+                    maker_token_a: offerValues.makerAccountA,
+                    vault: decoyVault.address,
+                    maker: offerValues.maker,
+                    programId: offerValues.programId,
+                }),
+            ]),
+        );
+    });
+
+    it('Refund Offer rejects a substitute maker_token_account_a', async () => {
+        // Regression test: refund_offer used to trust whatever account was
+        // passed as `maker_token_account_a` (the refund destination) without
+        // verifying it's the maker's actual canonical ATA - only the vault
+        // was checked. A malicious or compromised client could redirect the
+        // refund to an attacker-controlled account while the maker still
+        // signs, unaware the destination was swapped.
+        const offerValues = await createValues({
+            programId: values.programId,
+            maker: values.maker,
+            taker: values.taker,
+            mintAKeypair: values.mintAKeypair,
+            mintBKeypair: values.mintBKeypair,
+            id: 5n,
+        });
+
+        await sendInstructions(svm, payer, [
+            buildMakeOffer({
+                id: offerValues.id,
+                maker: offerValues.maker,
+                maker_token_a: offerValues.makerAccountA,
+                offer: offerValues.offer,
+                bump: offerValues.offerBump,
+                token_a_offered_amount: offerValues.amountA,
+                token_b_wanted_amount: offerValues.amountB,
+                vault: offerValues.vault,
+                mint_a: offerValues.mintAKeypair.address,
+                mint_b: offerValues.mintBKeypair.address,
+                payer,
+                programId: offerValues.programId,
+            }),
+        ]);
+
+        // Substitute the taker's (unrelated) token A account as the refund
+        // destination instead of the maker's own canonical ATA.
+        await expectRevert(
+            sendInstructions(svm, payer, [
+                buildRefundOffer({
+                    offer: offerValues.offer,
+                    mint_a: offerValues.mintAKeypair.address,
+                    maker_token_a: offerValues.takerAccountA,
+                    vault: offerValues.vault,
+                    maker: offerValues.maker,
                     programId: offerValues.programId,
                 }),
             ]),

--- a/tokens/escrow/pinocchio/tests/utils.ts
+++ b/tokens/escrow/pinocchio/tests/utils.ts
@@ -26,11 +26,14 @@ import { FailedTransactionMetadata, type LiteSVM } from 'litesvm';
 const addressEncoder = getAddressEncoder();
 
 export const expectRevert = async (promise: Promise<unknown>) => {
+    let reverted = false;
     try {
         await promise;
-        throw new Error('Expected a revert');
     } catch {
-        return;
+        reverted = true;
+    }
+    if (!reverted) {
+        throw new Error('Expected a revert');
     }
 };
 
@@ -136,14 +139,18 @@ export async function createValues(defaults?: TestValuesDefaults): Promise<TestV
     const maker = defaults?.maker ?? (await generateKeyPairSigner());
     const taker = defaults?.taker ?? (await generateKeyPairSigner());
 
-    // Making sure tokens are in the right order
-    let mintAKeypair = defaults?.mintAKeypair;
-    let mintBKeypair = defaults?.mintBKeypair;
-    if (!mintAKeypair || !mintBKeypair) {
-        mintAKeypair = mintAKeypair ?? (await generateKeyPairSigner());
-        mintBKeypair = mintBKeypair ?? (await generateKeyPairSigner());
-        while (addressValue(mintBKeypair.address) < addressValue(mintAKeypair.address)) {
+    // Making sure tokens are in the right order. Only the mint(s) NOT
+    // supplied by the caller are ever (re)generated, so a caller-provided
+    // mint is never silently discarded.
+    let mintAKeypair = defaults?.mintAKeypair ?? (await generateKeyPairSigner());
+    let mintBKeypair = defaults?.mintBKeypair ?? (await generateKeyPairSigner());
+    while (addressValue(mintBKeypair.address) < addressValue(mintAKeypair.address)) {
+        if (!defaults?.mintAKeypair) {
+            mintAKeypair = await generateKeyPairSigner();
+        } else if (!defaults?.mintBKeypair) {
             mintBKeypair = await generateKeyPairSigner();
+        } else {
+            throw new Error('mintAKeypair and mintBKeypair were both supplied out of the required address order');
         }
     }
 

--- a/tokens/escrow/pinocchio/tests/utils.ts
+++ b/tokens/escrow/pinocchio/tests/utils.ts
@@ -25,6 +25,15 @@ import { FailedTransactionMetadata, type LiteSVM } from 'litesvm';
 
 const addressEncoder = getAddressEncoder();
 
+export const expectRevert = async (promise: Promise<unknown>) => {
+    try {
+        await promise;
+        throw new Error('Expected a revert');
+    } catch {
+        return;
+    }
+};
+
 export async function sendInstructions(svm: LiteSVM, payer: KeyPairSigner, instructions: readonly Instruction[]) {
     const transactionMessage = pipe(
         createTransactionMessage({ version: 0 }),
@@ -117,17 +126,25 @@ function addressValue(address: Address): bigint {
     return addressEncoder.encode(address).reduce((total, byte) => (total << 8n) | BigInt(byte), 0n);
 }
 
-export async function createValues(defaults?: { id?: bigint }): Promise<TestValues> {
-    const programId = (await generateKeyPairSigner()).address;
+type TestValuesDefaults = {
+    [K in keyof TestValues]+?: TestValues[K];
+};
+
+export async function createValues(defaults?: TestValuesDefaults): Promise<TestValues> {
+    const programId = defaults?.programId ?? (await generateKeyPairSigner()).address;
     const id = defaults?.id ?? 0n;
-    const maker = await generateKeyPairSigner();
-    const taker = await generateKeyPairSigner();
+    const maker = defaults?.maker ?? (await generateKeyPairSigner());
+    const taker = defaults?.taker ?? (await generateKeyPairSigner());
 
     // Making sure tokens are in the right order
-    const mintAKeypair = await generateKeyPairSigner();
-    let mintBKeypair = await generateKeyPairSigner();
-    while (addressValue(mintBKeypair.address) < addressValue(mintAKeypair.address)) {
-        mintBKeypair = await generateKeyPairSigner();
+    let mintAKeypair = defaults?.mintAKeypair;
+    let mintBKeypair = defaults?.mintBKeypair;
+    if (!mintAKeypair || !mintBKeypair) {
+        mintAKeypair = mintAKeypair ?? (await generateKeyPairSigner());
+        mintBKeypair = mintBKeypair ?? (await generateKeyPairSigner());
+        while (addressValue(mintBKeypair.address) < addressValue(mintAKeypair.address)) {
+            mintBKeypair = await generateKeyPairSigner();
+        }
     }
 
     const [offer, offerBump] = await getProgramDerivedAddress({
@@ -157,8 +174,8 @@ export async function createValues(defaults?: { id?: bigint }): Promise<TestValu
         makerAccountB,
         takerAccountA,
         takerAccountB,
-        amountA: 4_000_000n,
-        amountB: 1_000_000n,
+        amountA: defaults?.amountA ?? 4_000_000n,
+        amountB: defaults?.amountB ?? 1_000_000n,
         programId,
     };
 }


### PR DESCRIPTION
## Summary

Escalated the same security-audit methodology from #667 (missing signer checks in `basics/`) to `tokens/escrow` — native, pinocchio, and anchor. Escrow/vault programs are the highest-value target for this kind of audit: they hold other people's funds in program custody, and this repo's version is what learners copy into real token-swap escrows.

### Bug (native only): broken post-transfer invariant lets a third party permanently freeze any offer

`take_offer`'s post-transfer sanity check compared the maker's token-B balance against the wrong variable:

```rust
assert_eq!(maker_amount_b, taker_amount_a_before_transfer + offer.token_b_wanted_amount); // BUG
```

`taker_amount_a_before_transfer` is a copy-paste of the line above, only half-edited — it should be `maker_amount_b_before_transfer`. The real SPL Token CPI always moves the correct amount, so this assert only happened to pass when the maker's token-B balance was exactly 0 before the trade. That's not guaranteed, and is trivially breakable by **any third party, no cooperation needed**: create the maker's token-B ATA (permissionless) and send it 1 base unit (also permissionless — no signature required from the recipient) before a `take_offer` call. From that point on, every `take_offer` for that offer panics and reverts.

### Gap (all three implementations): no way for a maker to reclaim their deposit

This is what turns the bug above from "annoying" into **permanent fund loss**: there was no `RefundOffer`/cancel instruction anywhere — not in native, not in pinocchio, not even in the anchor reference version. Only `MakeOffer`/`TakeOffer` existed. Once an offer is bricked (by the bug above, or simply because the counterparty never shows up — the ordinary non-adversarial case), the maker's deposited tokens were locked in the vault with no recovery path.

## Fixes

- One-line fix to the comparison in `native/program/src/instructions/take_offer.rs`.
- New `RefundOffer` instruction in **all three** implementations: only the maker (verified against the offer's stored `maker` field) can call it. Returns the vault's current token-A balance to the maker's own account, closes the vault and offer accounts, rent to the maker. Structurally mirrors each implementation's existing `take_offer` vault-drain-and-close logic — same seeds, same CPI shape — just redirecting the destination and dropping the token-B leg entirely (a refund never touches token B).

## Test plan

Every new test was verified to **fail against the unpatched/pre-feature code first** (confirming it actually exercises the bug/gap, not a false negative), then pass after the fix — same discipline as #667:

- [x] **native**: regression test pre-funds the maker's token-B account before `Take Offer` to reproduce the exact condition that broke the old assert (confirmed panic at `take_offer.rs:171` before the fix); `RefundOffer` happy-path and non-maker-cannot-refund tests. 6/6 passing.
- [x] **pinocchio**: same two `RefundOffer` tests (never had the assert bug — its `take_offer` has no equivalent check). 4/4 passing.
- [x] **anchor**: same two `RefundOffer` tests added to `litesvm.test.ts`. 4/4 passing. (The separate validator-based `escrow.test.ts` — pre-existing, untouched — couldn't be executed in this sandbox due to a local `solana-test-validator` startup issue unrelated to this change; the identical on-chain logic is already fully exercised via `litesvm.test.ts` against the same compiled program.)
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` clean for the root-workspace crates (native + pinocchio); `prettier --check` clean for all touched TS files. (`tokens/escrow/anchor` is its own nested Cargo workspace, outside the root workspace `cargo fmt`/`clippy` cover — consistent with the rest of the repo's `*/anchor/` programs.)
- [x] Added `#[allow(clippy::enum_variant_names)]` to native's `EscrowInstruction` enum — adding the third `RefundOffer` variant tripped the lint (it only fires at ≥3 variants), and the shared `Offer` postfix is intentional domain vocabulary matching the existing `MakeOffer`/`TakeOffer` naming, not something to rename.

## Incidental fix

Extended native's and pinocchio's test `createValues()` helper to actually respect all the overridable defaults its own type signature (`TestValuesDefaults`) already promised — it previously only read `programId`/`id` from the passed defaults and silently regenerated `maker`/`taker`/mint keypairs regardless, which made it impossible to create a second offer reusing the same already-funded accounts and already-deployed program (needed for the new tests, which create additional offers under the same setup).