### PR TITLE
fix(basics/close-account): reserve the 8-byte discriminator in create_user

### DIFF
--- a/basics/close-account/anchor/programs/close-account/src/instructions/create_user.rs
+++ b/basics/close-account/anchor/programs/close-account/src/instructions/create_user.rs
@@ -9,7 +9,7 @@ pub struct CreateUserContext<'info> {
     #[account(
         init,
         payer = user,
-        space = UserState::INIT_SPACE,
+        space = 8 + UserState::INIT_SPACE,
         seeds = [
             b"USER",
             user.key().as_ref(),


### PR DESCRIPTION
`create_user.rs` sizes the new account with `space = UserState::INIT_SPACE`,
which does not include Anchor's 8-byte account discriminator.

`InitSpace` measures the struct's own fields and stops there. For `UserState`:

    bump: u8                   1
    user: Pubkey              32
    #[max_len(50)] name       4 + 50
                            ----
                              87

The account therefore gets 87 bytes, but a serialized `UserState` needs
`8 + 4 + name.len() + 33`. Names up to 42 bytes fit inside 87. Names of 43 to
50 bytes — all of which `#[max_len(50)]` promises to support — overflow the
allocation and the instruction fails with `AccountDidNotSerialize`.

The test suite passes because it only ever writes `"John Doe"`, which is 8 bytes.

Every other Anchor example under `basics/` already accounts for the
discriminator, so this also brings `close-account` back in line with the rest
of the repository:

  - account-data              `ANCHOR_DISCRIMINATOR_SIZE + AddressInfo::INIT_SPACE`
  - favorites                 `ANCHOR_DISCRIMINATOR_SIZE + Favorites::INIT_SPACE`
  - counter                   `8 + Counter::INIT_SPACE`
  - program-derived-addresses `8 + PageVisits::INIT_SPACE`

### The change

`basics/close-account/anchor/programs/close-account/src/instructions/create_user.rs`

```diff
-        space = UserState::INIT_SPACE,
+        space = 8 + UserState::INIT_SPACE,
```

### Verifying

Changing the test to create a user with a 50-byte name fails before this
change and passes after it.

The `native` implementation is unaffected: it sizes the account with
`borsh::to_vec(&data)?.len()`, and native accounts carry no discriminator.
