### PR TITLE
docs(basics/favorites): discriminator comment — 8 bytes, not 8 bits

### DIFF
--- a/basics/favorites/anchor/programs/favorites/src/lib.rs
+++ b/basics/favorites/anchor/programs/favorites/src/lib.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 // This matches the key in the target/deploy directory
 declare_id!("ww9C83noARSQVBnqmCUmaVdbJjmiwcV9j2LkXYMoUCV");
 
-// Anchor programs always use 8 bits for the discriminator
+// Anchor programs always use 8 bytes for the discriminator
 pub const ANCHOR_DISCRIMINATOR_SIZE: usize = 8;
 
 // Our Solana program!


### PR DESCRIPTION
The comment above `ANCHOR_DISCRIMINATOR_SIZE` in
`basics/favorites/anchor/programs/favorites/src/lib.rs` reads:

```rust
// Anchor programs always use 8 bits for the discriminator
pub const ANCHOR_DISCRIMINATOR_SIZE: usize = 8;
```

Anchor's account discriminator is 8 *bytes* (the first 8 bytes of
`sha256("account:<StructName>")`), and that is what the constant below the
comment counts — it is added to `INIT_SPACE` in a `space` calculation, which
is measured in bytes.

### The change

```diff
-// Anchor programs always use 8 bits for the discriminator
+// Anchor programs always use 8 bytes for the discriminator
```

Since favorites is many people's first Anchor example, the unit is worth
getting right — a reader who takes "8 bits" literally would under-allocate
by 7 bytes in their own program.
