### PR TITLE
fix(abl-token): block wallets from sending, not just receiving

### DIFF
--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/Anchor.toml
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/Anchor.toml
@@ -17,4 +17,8 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "../node_modules/.bin/mocha --import=tsx -t 1000000 tests/**/*.ts"
+# cargo test runs both the tx_hook.rs unit tests and the litesvm
+# integration test - CI's Anchor workflow only runs this [scripts] test
+# command (never a separate `cargo test`), so without this the Rust-side
+# tests were never actually executed.
+test = "cargo test -p abl-token && ../node_modules/.bin/mocha --import=tsx -t 1000000 tests/**/*.ts"

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/Cargo.toml
@@ -34,6 +34,7 @@ spl-discriminator = "0.5.1"
 
 [dev-dependencies]
 litesvm = "0.11.0"
+solana-account = "3.2.0"
 solana-instruction = "3.0.0"
 solana-keypair = "3.0.1"
 solana-message = "3.1.0"

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/errors.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/errors.rs
@@ -13,4 +13,7 @@ pub enum ABListError {
 
     #[msg("Wallet blocked")]
     WalletBlocked,
+
+    #[msg("Mint is not configured to use this transfer hook program")]
+    MintNotUsingThisHook,
 }

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/change_mode.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/change_mode.rs
@@ -8,8 +8,8 @@ use anchor_spl::{
         Token2022,
     },
     token_interface::{
-        spl_token_metadata_interface::state::Field, token_metadata_update_field,
-        Mint as MintAccount, TokenMetadataUpdateField,
+        spl_token_metadata_interface::state::Field, token_metadata_update_field, Mint as MintAccount,
+        TokenMetadataUpdateField,
     },
 };
 
@@ -50,11 +50,7 @@ impl ChangeMode<'_> {
         token_metadata_update_field(cpi_ctx, Field::Key("AB".to_string()), args.mode.to_string())?;
 
         if args.mode == Mode::Mixed || self.has_threshold()? {
-            let threshold = if args.mode == Mode::Mixed {
-                args.threshold
-            } else {
-                0
-            };
+            let threshold = if args.mode == Mode::Mixed { args.threshold } else { 0 };
 
             let cpi_accounts = TokenMetadataUpdateField {
                 metadata: self.mint.to_account_info(),
@@ -64,11 +60,7 @@ impl ChangeMode<'_> {
             let cpi_program = self.token_program.key();
             let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
 
-            token_metadata_update_field(
-                cpi_ctx,
-                Field::Key("threshold".to_string()),
-                threshold.to_string(),
-            )?;
+            token_metadata_update_field(cpi_ctx, Field::Key("threshold".to_string()), threshold.to_string())?;
         }
 
         let data = self.mint.to_account_info().data_len();
@@ -80,11 +72,7 @@ impl ChangeMode<'_> {
                     &self.mint.to_account_info().key(),
                     min_balance - self.mint.to_account_info().get_lamports(),
                 ),
-                &[
-                    self.authority.to_account_info(),
-                    self.mint.to_account_info(),
-                    self.system_program.to_account_info(),
-                ],
+                &[self.authority.to_account_info(), self.mint.to_account_info(), self.system_program.to_account_info()],
             )?;
         }
 
@@ -96,11 +84,6 @@ impl ChangeMode<'_> {
         let mint_data = mint_info.data.borrow();
         let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
         let metadata = mint.get_variable_len_extension::<TokenMetadata>();
-        Ok(metadata.is_ok()
-            && metadata
-                .unwrap()
-                .additional_metadata
-                .iter()
-                .any(|(key, _)| key == "threshold"))
+        Ok(metadata.is_ok() && metadata.unwrap().additional_metadata.iter().any(|(key, _)| key == "threshold"))
     }
 }

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/init_config.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/init_config.rs
@@ -20,10 +20,7 @@ pub struct InitConfig<'info> {
 
 impl InitConfig<'_> {
     pub fn init_config(&mut self, config_bump: u8) -> Result<()> {
-        self.config.set_inner(Config {
-            authority: self.payer.key(),
-            bump: config_bump,
-        });
+        self.config.set_inner(Config { authority: self.payer.key(), bump: config_bump });
 
         Ok(())
     }

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/init_mint.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/init_mint.rs
@@ -1,11 +1,9 @@
-use anchor_lang::{
-    prelude::*, solana_program::program::invoke, solana_program::system_instruction::transfer,
-};
+use anchor_lang::{prelude::*, solana_program::program::invoke, solana_program::system_instruction::transfer};
 use anchor_spl::{
     token_2022::Token2022,
     token_interface::{
-        spl_token_metadata_interface::state::Field, token_metadata_initialize,
-        token_metadata_update_field, Mint, TokenMetadataInitialize, TokenMetadataUpdateField,
+        spl_token_metadata_interface::state::Field, token_metadata_initialize, token_metadata_update_field, Mint,
+        TokenMetadataInitialize, TokenMetadataUpdateField,
     },
 };
 
@@ -80,11 +78,7 @@ impl InitMint<'_> {
             };
             let cpi_ctx = CpiContext::new(self.token_program.key(), cpi_accounts);
 
-            token_metadata_update_field(
-                cpi_ctx,
-                Field::Key("threshold".to_string()),
-                args.threshold.to_string(),
-            )?;
+            token_metadata_update_field(cpi_ctx, Field::Key("threshold".to_string()), args.threshold.to_string())?;
         }
 
         let data = self.mint.to_account_info().data_len();
@@ -96,11 +90,7 @@ impl InitMint<'_> {
                     &self.mint.to_account_info().key(),
                     min_balance - self.mint.to_account_info().get_lamports(),
                 ),
-                &[
-                    self.payer.to_account_info(),
-                    self.mint.to_account_info(),
-                    self.system_program.to_account_info(),
-                ],
+                &[self.payer.to_account_info(), self.mint.to_account_info(), self.system_program.to_account_info()],
             )?;
         }
 

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/mod.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/mod.rs
@@ -4,6 +4,7 @@ pub mod init_config;
 pub mod init_mint;
 pub mod init_wallet;
 pub mod remove_wallet;
+pub mod resize_meta_list;
 pub mod tx_hook;
 
 pub use attach_to_mint::*;
@@ -12,4 +13,5 @@ pub use init_config::*;
 pub use init_mint::*;
 pub use init_wallet::*;
 pub use remove_wallet::*;
+pub use resize_meta_list::*;
 pub use tx_hook::*;

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/resize_meta_list.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/resize_meta_list.rs
@@ -1,30 +1,32 @@
 use anchor_lang::{prelude::*, solana_program::program::invoke, solana_program::system_instruction::transfer};
 use anchor_spl::{
-    token_2022::Token2022,
-    token_interface::{transfer_hook_update, Mint, TransferHookUpdate},
+    token_2022::{
+        spl_token_2022::{
+            extension::{transfer_hook, StateWithExtensions},
+            state::Mint as MintState,
+        },
+        Token2022,
+    },
+    token_interface::Mint,
 };
 
 use spl_tlv_account_resolution::state::ExtraAccountMetaList;
 use spl_transfer_hook_interface::instruction::ExecuteInstruction;
 
-use crate::{get_extra_account_metas, get_meta_list_size, META_LIST_ACCOUNT_SEED};
+use crate::{get_extra_account_metas, get_meta_list_size, ABListError, META_LIST_ACCOUNT_SEED};
 
 /// Rewrites an existing mint's extra-metas account to the current
 /// `get_extra_account_metas()` layout, reallocating it if the size changed.
-///
-/// This exists because `extra_metas_account` is a fixed-size PDA created once
-/// by `init_mint`/`attach_to_mint`: if the program's extra-account list is
-/// ever extended (e.g. to add the source-wallet check), mints that were set
-/// up under the old layout are left with a stale, undersized account and
-/// their transfers start failing the hook's account-count check. Any mint
-/// authority can call this to bring an existing mint's extra-metas account
-/// back in sync after such an upgrade.
+/// Permissionless: the content is fully determined by `mint` and this
+/// program's own fixed extra-account list, so nothing needs a signature -
+/// gating on the transfer-hook authority would strand mints whose authority
+/// was revoked.
 #[derive(Accounts)]
 pub struct ResizeMetaList<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
 
-    #[account(mut, mint::token_program = token_program)]
+    #[account(mint::token_program = token_program)]
     pub mint: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(
@@ -42,18 +44,15 @@ pub struct ResizeMetaList<'info> {
 
 impl ResizeMetaList<'_> {
     pub fn resize_meta_list(&mut self) -> Result<()> {
-        // Re-setting the transfer hook to itself has no effect on the mint,
-        // but the CPI only succeeds if `payer` is the mint's current
-        // transfer-hook authority - the same check `attach_to_mint` relies
-        // on, reused here so this instruction can't be called by anyone
-        // other than whoever is already trusted to configure this mint's hook.
-        let tx_hook_accs = TransferHookUpdate {
-            token_program_id: self.token_program.to_account_info(),
-            mint: self.mint.to_account_info(),
-            authority: self.payer.to_account_info(),
+        // Confirm the mint is actually configured to use this hook program -
+        // read directly from its TransferHook extension, no CPI needed.
+        let configured_program_id = {
+            let mint_info = self.mint.to_account_info();
+            let mint_data = mint_info.data.borrow();
+            let mint_state = StateWithExtensions::<MintState>::unpack(&mint_data)?;
+            transfer_hook::get_program_id(&mint_state)
         };
-        let ctx = CpiContext::new(self.token_program.key(), tx_hook_accs);
-        transfer_hook_update(ctx, Some(crate::ID_CONST))?;
+        require!(configured_program_id == Some(crate::ID_CONST), ABListError::MintNotUsingThisHook);
 
         let account_info = self.extra_metas_account.to_account_info();
         let new_size = get_meta_list_size()?;

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/resize_meta_list.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/resize_meta_list.rs
@@ -1,6 +1,4 @@
-use anchor_lang::{
-    prelude::*, solana_program::program::invoke, solana_program::system_instruction::transfer,
-};
+use anchor_lang::{prelude::*, solana_program::program::invoke, solana_program::system_instruction::transfer};
 use anchor_spl::{
     token_2022::Token2022,
     token_interface::{transfer_hook_update, Mint, TransferHookUpdate},

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/resize_meta_list.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/resize_meta_list.rs
@@ -1,0 +1,79 @@
+use anchor_lang::{
+    prelude::*, solana_program::program::invoke, solana_program::system_instruction::transfer,
+};
+use anchor_spl::{
+    token_2022::Token2022,
+    token_interface::{transfer_hook_update, Mint, TransferHookUpdate},
+};
+
+use spl_tlv_account_resolution::state::ExtraAccountMetaList;
+use spl_transfer_hook_interface::instruction::ExecuteInstruction;
+
+use crate::{get_extra_account_metas, get_meta_list_size, META_LIST_ACCOUNT_SEED};
+
+/// Rewrites an existing mint's extra-metas account to the current
+/// `get_extra_account_metas()` layout, reallocating it if the size changed.
+///
+/// This exists because `extra_metas_account` is a fixed-size PDA created once
+/// by `init_mint`/`attach_to_mint`: if the program's extra-account list is
+/// ever extended (e.g. to add the source-wallet check), mints that were set
+/// up under the old layout are left with a stale, undersized account and
+/// their transfers start failing the hook's account-count check. Any mint
+/// authority can call this to bring an existing mint's extra-metas account
+/// back in sync after such an upgrade.
+#[derive(Accounts)]
+pub struct ResizeMetaList<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    #[account(mut, mint::token_program = token_program)]
+    pub mint: Box<InterfaceAccount<'info, Mint>>,
+
+    #[account(
+        mut,
+        seeds = [META_LIST_ACCOUNT_SEED, mint.key().as_ref()],
+        bump,
+    )]
+    /// CHECK: extra metas account
+    pub extra_metas_account: UncheckedAccount<'info>,
+
+    pub system_program: Program<'info, System>,
+
+    pub token_program: Program<'info, Token2022>,
+}
+
+impl ResizeMetaList<'_> {
+    pub fn resize_meta_list(&mut self) -> Result<()> {
+        // Re-setting the transfer hook to itself has no effect on the mint,
+        // but the CPI only succeeds if `payer` is the mint's current
+        // transfer-hook authority - the same check `attach_to_mint` relies
+        // on, reused here so this instruction can't be called by anyone
+        // other than whoever is already trusted to configure this mint's hook.
+        let tx_hook_accs = TransferHookUpdate {
+            token_program_id: self.token_program.to_account_info(),
+            mint: self.mint.to_account_info(),
+            authority: self.payer.to_account_info(),
+        };
+        let ctx = CpiContext::new(self.token_program.key(), tx_hook_accs);
+        transfer_hook_update(ctx, Some(crate::ID_CONST))?;
+
+        let account_info = self.extra_metas_account.to_account_info();
+        let new_size = get_meta_list_size()?;
+
+        let min_balance = Rent::get()?.minimum_balance(new_size);
+        if min_balance > account_info.lamports() {
+            invoke(
+                &transfer(&self.payer.key(), account_info.key, min_balance - account_info.lamports()),
+                &[self.payer.to_account_info(), account_info.clone(), self.system_program.to_account_info()],
+            )?;
+        }
+        account_info.resize(new_size)?;
+
+        let metas = get_extra_account_metas()?;
+        let mut data = account_info.try_borrow_mut_data()?;
+        ExtraAccountMetaList::update::<ExecuteInstruction>(&mut data, &metas)
+            .map_err(|_| ProgramError::InvalidAccountData)?;
+
+        Ok(())
+    }
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/tx_hook.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/instructions/tx_hook.rs
@@ -24,7 +24,9 @@ pub struct TxHook<'info> {
     /// CHECK:
     pub meta_list: UncheckedAccount<'info>,
     /// CHECK:
-    pub ab_wallet: UncheckedAccount<'info>,
+    pub source_ab_wallet: UncheckedAccount<'info>,
+    /// CHECK:
+    pub destination_ab_wallet: UncheckedAccount<'info>,
 }
 
 impl TxHook<'_> {
@@ -35,31 +37,18 @@ impl TxHook<'_> {
 
         let metadata = mint.get_variable_len_extension::<TokenMetadata>()?;
         let decoded_mode = Self::decode_metadata(&metadata)?;
-        let decoded_wallet_mode = self.decode_wallet_mode()?;
+        let source_wallet_mode = Self::decode_wallet_mode(&self.source_ab_wallet)?;
+        let destination_wallet_mode = Self::decode_wallet_mode(&self.destination_ab_wallet)?;
 
-        match (decoded_mode, decoded_wallet_mode) {
-            // first check the force allow modes
-            (DecodedMintMode::Allow, DecodedWalletMode::Allow) => Ok(()),
-            (DecodedMintMode::Allow, _) => Err(ABListError::WalletNotAllowed.into()),
-            // then check if the wallet is blocked
-            (_, DecodedWalletMode::Block) => Err(ABListError::WalletBlocked.into()),
-            (DecodedMintMode::Block, _) => Ok(()),
-            // lastly check the threshold mode
-            (DecodedMintMode::Threshold(threshold), DecodedWalletMode::None)
-                if amount >= threshold =>
-            {
-                Err(ABListError::AmountNotAllowed.into())
-            }
-            (DecodedMintMode::Threshold(_), _) => Ok(()),
-        }
+        decide(decoded_mode, source_wallet_mode, destination_wallet_mode, amount)
     }
 
-    fn decode_wallet_mode(&self) -> Result<DecodedWalletMode> {
-        if self.ab_wallet.data_is_empty() {
+    fn decode_wallet_mode(account: &UncheckedAccount) -> Result<DecodedWalletMode> {
+        if account.data_is_empty() {
             return Ok(DecodedWalletMode::None);
         }
 
-        let wallet_data = &mut self.ab_wallet.data.borrow();
+        let wallet_data = &mut account.data.borrow();
         let wallet = ABWallet::try_deserialize(&mut &wallet_data[..])?;
 
         if wallet.allowed {
@@ -106,14 +95,132 @@ impl TxHook<'_> {
     }
 }
 
+/// The transfer decision, kept as a pure function of the decoded mint/wallet
+/// state so it's directly unit-testable without needing real accounts.
+///
+/// A wallet with an explicit `allowed: false` ABWallet record is blocked from
+/// transacting entirely - neither sending nor receiving - regardless of the
+/// mint's overall mode. This is checked first and applies to both sides.
+///
+/// Beyond that, Allow/Threshold mode gate who may *receive* only, matching
+/// this program's documented semantics (see README): Force Allow requires
+/// the receiver to be explicitly allowed in; Threshold requires the receiver
+/// to be explicitly allowed in for transfers at or above the threshold.
+fn decide(
+    mint_mode: DecodedMintMode,
+    source_wallet_mode: DecodedWalletMode,
+    destination_wallet_mode: DecodedWalletMode,
+    amount: u64,
+) -> Result<()> {
+    if source_wallet_mode == DecodedWalletMode::Block || destination_wallet_mode == DecodedWalletMode::Block {
+        return Err(ABListError::WalletBlocked.into());
+    }
+
+    match (mint_mode, destination_wallet_mode) {
+        // first check the force allow modes
+        (DecodedMintMode::Allow, DecodedWalletMode::Allow) => Ok(()),
+        (DecodedMintMode::Allow, _) => Err(ABListError::WalletNotAllowed.into()),
+        // block mode: neither wallet was explicitly blocked (checked above), so allow
+        (DecodedMintMode::Block, _) => Ok(()),
+        // lastly check the threshold mode
+        (DecodedMintMode::Threshold(threshold), DecodedWalletMode::None) if amount >= threshold => {
+            Err(ABListError::AmountNotAllowed.into())
+        }
+        (DecodedMintMode::Threshold(_), _) => Ok(()),
+    }
+}
+
+#[derive(Debug, PartialEq)]
 enum DecodedMintMode {
     Allow,
     Block,
     Threshold(u64),
 }
 
+#[derive(Debug, PartialEq)]
 enum DecodedWalletMode {
     Allow,
     Block,
     None,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_blocked_is_always_rejected() {
+        // This is the exact case that was broken: a blocked SENDER used to
+        // be allowed through, since only the destination was ever checked.
+        for mint_mode in [DecodedMintMode::Allow, DecodedMintMode::Block, DecodedMintMode::Threshold(100)] {
+            for destination_mode in [DecodedWalletMode::Allow, DecodedWalletMode::Block, DecodedWalletMode::None] {
+                let result = decide(mint_mode_clone(&mint_mode), DecodedWalletMode::Block, destination_mode, 0);
+                assert!(
+                    result.is_err(),
+                    "expected a blocked source to be rejected regardless of mint mode / destination status"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn destination_blocked_is_always_rejected() {
+        // Regression guard: this already worked before the fix, must keep working.
+        for mint_mode in [DecodedMintMode::Allow, DecodedMintMode::Block, DecodedMintMode::Threshold(100)] {
+            for source_mode in [DecodedWalletMode::Allow, DecodedWalletMode::Block, DecodedWalletMode::None] {
+                let result = decide(mint_mode_clone(&mint_mode), source_mode, DecodedWalletMode::Block, 0);
+                assert!(
+                    result.is_err(),
+                    "expected a blocked destination to be rejected regardless of mint mode / source status"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn allow_mode_does_not_gate_the_source() {
+        // The source is intentionally NOT gated in Allow mode - only "who may
+        // receive" is documented/intended to be restricted. This is the
+        // control case proving the fix doesn't over-correct.
+        let result = decide(DecodedMintMode::Allow, DecodedWalletMode::None, DecodedWalletMode::Allow, 0);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn allow_mode_rejects_an_unlisted_destination() {
+        let result = decide(DecodedMintMode::Allow, DecodedWalletMode::None, DecodedWalletMode::None, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn block_mode_allows_unlisted_wallets() {
+        let result = decide(DecodedMintMode::Block, DecodedWalletMode::None, DecodedWalletMode::None, 0);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn threshold_mode_allows_small_transfers_to_unlisted_destinations() {
+        let result = decide(DecodedMintMode::Threshold(100), DecodedWalletMode::None, DecodedWalletMode::None, 50);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn threshold_mode_rejects_large_transfers_to_unlisted_destinations() {
+        let result = decide(DecodedMintMode::Threshold(100), DecodedWalletMode::None, DecodedWalletMode::None, 100);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn threshold_mode_allows_large_transfers_to_an_allowed_destination() {
+        let result = decide(DecodedMintMode::Threshold(100), DecodedWalletMode::None, DecodedWalletMode::Allow, 100);
+        assert!(result.is_ok());
+    }
+
+    fn mint_mode_clone(mode: &DecodedMintMode) -> DecodedMintMode {
+        match mode {
+            DecodedMintMode::Allow => DecodedMintMode::Allow,
+            DecodedMintMode::Block => DecodedMintMode::Block,
+            DecodedMintMode::Threshold(t) => DecodedMintMode::Threshold(*t),
+        }
+    }
 }

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/lib.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/lib.rs
@@ -48,4 +48,8 @@ pub mod abl_token {
     pub fn change_mode(ctx: Context<ChangeMode>, args: ChangeModeArgs) -> Result<()> {
         ctx.accounts.change_mode(args)
     }
+
+    pub fn resize_meta_list(ctx: Context<ResizeMetaList>) -> Result<()> {
+        ctx.accounts.resize_meta_list()
+    }
 }

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/utils.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/utils.rs
@@ -7,12 +7,27 @@ use spl_tlv_account_resolution::{
 use crate::AB_WALLET_SEED;
 
 pub fn get_meta_list_size() -> Result<usize> {
-    Ok(ExtraAccountMetaList::size_of(1).map_err(|_| ProgramError::InvalidArgument)?)
+    Ok(ExtraAccountMetaList::size_of(2).map_err(|_| ProgramError::InvalidArgument)?)
 }
 
 pub fn get_extra_account_metas() -> Result<Vec<ExtraAccountMeta>> {
     Ok(vec![
-        // [5] ab_wallet for destination token account wallet
+        // [5] ab_wallet for source token account wallet
+        ExtraAccountMeta::new_with_seeds(
+            &[
+                Seed::Literal {
+                    bytes: AB_WALLET_SEED.to_vec(),
+                },
+                Seed::AccountData {
+                    account_index: 0,
+                    data_index: 32,
+                    length: 32,
+                },
+            ],
+            false,
+            false,
+        ).map_err(|_| ProgramError::InvalidArgument)?, // [0] source token account
+        // [6] ab_wallet for destination token account wallet
         ExtraAccountMeta::new_with_seeds(
             &[
                 Seed::Literal {

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/utils.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/src/utils.rs
@@ -1,13 +1,15 @@
 use anchor_lang::prelude::*;
 
-use spl_tlv_account_resolution::{
-    account::ExtraAccountMeta, seeds::Seed, state::ExtraAccountMetaList,
-};
+use spl_tlv_account_resolution::{account::ExtraAccountMeta, seeds::Seed, state::ExtraAccountMetaList};
 
 use crate::AB_WALLET_SEED;
 
+/// The transfer hook resolves one extra account per side of a transfer: the
+/// source wallet's ab_wallet PDA and the destination wallet's ab_wallet PDA.
+const NUM_EXTRA_ACCOUNTS: usize = 2;
+
 pub fn get_meta_list_size() -> Result<usize> {
-    Ok(ExtraAccountMetaList::size_of(2).map_err(|_| ProgramError::InvalidArgument)?)
+    Ok(ExtraAccountMetaList::size_of(NUM_EXTRA_ACCOUNTS).map_err(|_| ProgramError::InvalidArgument)?)
 }
 
 pub fn get_extra_account_metas() -> Result<Vec<ExtraAccountMeta>> {
@@ -15,32 +17,22 @@ pub fn get_extra_account_metas() -> Result<Vec<ExtraAccountMeta>> {
         // [5] ab_wallet for source token account wallet
         ExtraAccountMeta::new_with_seeds(
             &[
-                Seed::Literal {
-                    bytes: AB_WALLET_SEED.to_vec(),
-                },
-                Seed::AccountData {
-                    account_index: 0,
-                    data_index: 32,
-                    length: 32,
-                },
+                Seed::Literal { bytes: AB_WALLET_SEED.to_vec() },
+                Seed::AccountData { account_index: 0, data_index: 32, length: 32 },
             ],
             false,
             false,
-        ).map_err(|_| ProgramError::InvalidArgument)?, // [0] source token account
+        )
+        .map_err(|_| ProgramError::InvalidArgument)?, // [0] source token account
         // [6] ab_wallet for destination token account wallet
         ExtraAccountMeta::new_with_seeds(
             &[
-                Seed::Literal {
-                    bytes: AB_WALLET_SEED.to_vec(),
-                },
-                Seed::AccountData {
-                    account_index: 2,
-                    data_index: 32,
-                    length: 32,
-                },
+                Seed::Literal { bytes: AB_WALLET_SEED.to_vec() },
+                Seed::AccountData { account_index: 2, data_index: 32, length: 32 },
             ],
             false,
             false,
-        ).map_err(|_| ProgramError::InvalidArgument)?, // [2] destination token account
+        )
+        .map_err(|_| ProgramError::InvalidArgument)?, // [2] destination token account
     ])
 }

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/tests/test.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/tests/test.rs
@@ -1,8 +1,5 @@
 use {
-    abl_token::{
-        accounts::InitConfig, accounts::InitMint, accounts::ResizeMetaList,
-        instructions::InitMintArgs, Mode,
-    },
+    abl_token::{accounts::InitConfig, accounts::InitMint, accounts::ResizeMetaList, instructions::InitMintArgs, Mode},
     anchor_lang::InstructionData,
     anchor_lang::ToAccountMetas,
     anchor_spl::token_2022::ID as TOKEN_22_PROGRAM_ID,
@@ -55,19 +52,11 @@ fn setup_mint(svm: &mut LiteSVM, admin_kp: &Keypair) -> (Pubkey, Pubkey) {
 
     let init_cfg_ix = abl_token::instruction::InitConfig {};
 
-    let init_cfg_accounts = InitConfig {
-        payer: admin_pk,
-        config: config,
-        system_program: SYSTEM_PROGRAM_ID,
-    };
+    let init_cfg_accounts = InitConfig { payer: admin_pk, config: config, system_program: SYSTEM_PROGRAM_ID };
 
     let accs = init_cfg_accounts.to_account_metas(None);
 
-    let instruction = Instruction {
-        program_id: PROGRAM_ID,
-        accounts: accs,
-        data: init_cfg_ix.data(),
-    };
+    let instruction = Instruction { program_id: PROGRAM_ID, accounts: accs, data: init_cfg_ix.data() };
     let msg = Message::new(&[instruction], Some(&admin_pk));
     let tx = Transaction::new(&[admin_kp], msg, svm.latest_blockhash());
 
@@ -99,11 +88,7 @@ fn setup_mint(svm: &mut LiteSVM, admin_kp: &Keypair) -> (Pubkey, Pubkey) {
 
     let accs = init_mint_accounts.to_account_metas(None);
 
-    let instruction = Instruction {
-        program_id: PROGRAM_ID,
-        accounts: accs,
-        data: data,
-    };
+    let instruction = Instruction { program_id: PROGRAM_ID, accounts: accs, data: data };
     let msg = Message::new(&[instruction], Some(&admin_pk));
     let tx = Transaction::new(&[admin_kp, &mint_kp], msg, svm.latest_blockhash());
 
@@ -113,7 +98,7 @@ fn setup_mint(svm: &mut LiteSVM, admin_kp: &Keypair) -> (Pubkey, Pubkey) {
 }
 
 #[test]
-fn test() {
+fn init_config_and_init_mint_succeed() {
     let (mut svm, admin_kp) = setup();
     setup_mint(&mut svm, &admin_kp);
 }
@@ -213,11 +198,7 @@ fn resize_meta_list_migrates_a_mint_created_under_the_old_one_entry_layout() {
     let current_account = svm.get_account(&meta_list).unwrap();
     svm.set_account(
         meta_list,
-        Account {
-            lamports: svm.minimum_balance_for_rent_exemption(old_size),
-            data: old_data,
-            ..current_account
-        },
+        Account { lamports: svm.minimum_balance_for_rent_exemption(old_size), data: old_data, ..current_account },
     )
     .unwrap();
     assert_eq!(svm.get_account(&meta_list).unwrap().data.len(), old_size);

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/tests/test.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/tests/test.rs
@@ -1,8 +1,16 @@
 use {
     abl_token::{accounts::InitConfig, accounts::InitMint, accounts::ResizeMetaList, instructions::InitMintArgs, Mode},
+    anchor_lang::solana_program::system_instruction::create_account,
     anchor_lang::InstructionData,
     anchor_lang::ToAccountMetas,
-    anchor_spl::token_2022::ID as TOKEN_22_PROGRAM_ID,
+    anchor_spl::token_2022::{
+        spl_token_2022::{
+            self,
+            extension::{transfer_hook, ExtensionType},
+            instruction::initialize_mint2,
+        },
+        ID as TOKEN_22_PROGRAM_ID,
+    },
     litesvm::LiteSVM,
     solana_account::Account,
     solana_instruction::Instruction,
@@ -104,7 +112,7 @@ fn init_config_and_init_mint_succeed() {
 }
 
 #[test]
-fn resize_meta_list_succeeds_for_the_mints_transfer_hook_authority() {
+fn resize_meta_list_succeeds_and_is_idempotent() {
     let (mut svm, admin_kp) = setup();
     let admin_pk = admin_kp.pubkey();
     let (mint_pk, meta_list) = setup_mint(&mut svm, &admin_kp);
@@ -139,21 +147,20 @@ fn resize_meta_list_succeeds_for_the_mints_transfer_hook_authority() {
 }
 
 #[test]
-fn resize_meta_list_rejects_a_non_authority_signer() {
+fn resize_meta_list_is_permissionless() {
+    // Deliberately permissionless: gating this on the mint's transfer-hook
+    // authority would permanently strand any mint whose authority was
+    // revoked, since the content written doesn't depend on who calls it.
     let (mut svm, admin_kp) = setup();
     let (mint_pk, meta_list) = setup_mint(&mut svm, &admin_kp);
 
-    let attacker_kp = Keypair::new();
-    let attacker_pk = attacker_kp.pubkey();
-    svm.airdrop(&attacker_pk, 10 * LAMPORTS_PER_SOL).unwrap();
+    let stranger_kp = Keypair::new();
+    let stranger_pk = stranger_kp.pubkey();
+    svm.airdrop(&stranger_pk, 10 * LAMPORTS_PER_SOL).unwrap();
 
-    // Anyone can pay for the resize, but the CPI back into Token-2022's
-    // `update_transfer_hook` only succeeds if the signer is the mint's real
-    // transfer-hook authority (`admin_pk`, not `attacker_pk`) - that's what
-    // gates this instruction, since it has no authority table of its own.
     let resize_ix = abl_token::instruction::ResizeMetaList {};
     let resize_accounts = ResizeMetaList {
-        payer: attacker_pk,
+        payer: stranger_pk,
         mint: mint_pk,
         extra_metas_account: meta_list,
         system_program: SYSTEM_PROGRAM_ID,
@@ -164,11 +171,58 @@ fn resize_meta_list_rejects_a_non_authority_signer() {
         accounts: resize_accounts.to_account_metas(None),
         data: resize_ix.data(),
     };
-    let msg = Message::new(&[instruction], Some(&attacker_pk));
-    let tx = Transaction::new(&[&attacker_kp], msg, svm.latest_blockhash());
+    let msg = Message::new(&[instruction], Some(&stranger_pk));
+    let tx = Transaction::new(&[&stranger_kp], msg, svm.latest_blockhash());
+
+    svm.send_transaction(tx).unwrap();
+}
+
+#[test]
+fn resize_meta_list_rejects_a_mint_not_using_this_hook() {
+    let (mut svm, admin_kp) = setup();
+    let admin_pk = admin_kp.pubkey();
+
+    // A mint whose TransferHook extension points at some other program.
+    let mint_kp = Keypair::new();
+    let mint_pk = mint_kp.pubkey();
+    let other_program = Pubkey::new_unique();
+
+    let space = ExtensionType::try_calculate_account_len::<spl_token_2022::state::Mint>(&[ExtensionType::TransferHook])
+        .unwrap();
+    let rent = svm.minimum_balance_for_rent_exemption(space);
+
+    let create_ix = create_account(&admin_pk, &mint_pk, rent, space as u64, &TOKEN_22_PROGRAM_ID);
+    let init_hook_ix =
+        transfer_hook::instruction::initialize(&TOKEN_22_PROGRAM_ID, &mint_pk, Some(admin_pk), Some(other_program))
+            .unwrap();
+    let init_mint_ix = initialize_mint2(&TOKEN_22_PROGRAM_ID, &mint_pk, &admin_pk, None, 6).unwrap();
+
+    let tx = Transaction::new(
+        &[&admin_kp, &mint_kp],
+        Message::new(&[create_ix, init_hook_ix, init_mint_ix], Some(&admin_pk)),
+        svm.latest_blockhash(),
+    );
+    svm.send_transaction(tx).unwrap();
+
+    let meta_list = derive_meta_list(&mint_pk);
+    let resize_ix = abl_token::instruction::ResizeMetaList {};
+    let resize_accounts = ResizeMetaList {
+        payer: admin_pk,
+        mint: mint_pk,
+        extra_metas_account: meta_list,
+        system_program: SYSTEM_PROGRAM_ID,
+        token_program: TOKEN_22_PROGRAM_ID,
+    };
+    let instruction = Instruction {
+        program_id: PROGRAM_ID,
+        accounts: resize_accounts.to_account_metas(None),
+        data: resize_ix.data(),
+    };
+    let msg = Message::new(&[instruction], Some(&admin_pk));
+    let tx = Transaction::new(&[&admin_kp], msg, svm.latest_blockhash());
 
     let res = svm.send_transaction(tx);
-    assert!(res.is_err(), "a non-authority signer must not be able to resize another mint's meta list");
+    assert!(res.is_err(), "resizing a mint that isn't using this hook program must be rejected");
 }
 
 #[test]

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/tests/test.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/anchor/programs/abl-token/tests/test.rs
@@ -1,9 +1,13 @@
 use {
-    abl_token::{accounts::InitConfig, accounts::InitMint, instructions::InitMintArgs, Mode},
+    abl_token::{
+        accounts::InitConfig, accounts::InitMint, accounts::ResizeMetaList,
+        instructions::InitMintArgs, Mode,
+    },
     anchor_lang::InstructionData,
     anchor_lang::ToAccountMetas,
     anchor_spl::token_2022::ID as TOKEN_22_PROGRAM_ID,
     litesvm::LiteSVM,
+    solana_account::Account,
     solana_instruction::Instruction,
     solana_keypair::Keypair,
     solana_message::Message,
@@ -12,6 +16,8 @@ use {
     solana_sdk_ids::system_program::ID as SYSTEM_PROGRAM_ID,
     solana_signer::Signer,
     solana_transaction::Transaction,
+    spl_tlv_account_resolution::{account::ExtraAccountMeta, seeds::Seed, state::ExtraAccountMetaList},
+    spl_transfer_hook_interface::instruction::ExecuteInstruction,
     std::path::PathBuf,
 };
 
@@ -36,9 +42,10 @@ fn setup() -> (LiteSVM, Keypair) {
     (svm, admin_kp)
 }
 
-#[test]
-fn test() {
-    let (mut svm, admin_kp) = setup();
+/// Runs `init_config` then `init_mint` (with `admin_pk` as the mint's
+/// `transfer_hook_authority`) and returns the resulting mint + meta-list
+/// pubkeys, so tests that need a live mint don't have to repeat the setup.
+fn setup_mint(svm: &mut LiteSVM, admin_kp: &Keypair) -> (Pubkey, Pubkey) {
     let admin_pk = admin_kp.pubkey();
 
     let mint_kp = Keypair::new();
@@ -62,7 +69,7 @@ fn test() {
         data: init_cfg_ix.data(),
     };
     let msg = Message::new(&[instruction], Some(&admin_pk));
-    let tx = Transaction::new(&[&admin_kp], msg, svm.latest_blockhash());
+    let tx = Transaction::new(&[admin_kp], msg, svm.latest_blockhash());
 
     svm.send_transaction(tx).unwrap();
 
@@ -98,9 +105,151 @@ fn test() {
         data: data,
     };
     let msg = Message::new(&[instruction], Some(&admin_pk));
-    let tx = Transaction::new(&[&admin_kp, &mint_kp], msg, svm.latest_blockhash());
+    let tx = Transaction::new(&[admin_kp, &mint_kp], msg, svm.latest_blockhash());
 
-    let _res = svm.send_transaction(tx).unwrap();
+    svm.send_transaction(tx).unwrap();
+
+    (mint_pk, meta_list)
+}
+
+#[test]
+fn test() {
+    let (mut svm, admin_kp) = setup();
+    setup_mint(&mut svm, &admin_kp);
+}
+
+#[test]
+fn resize_meta_list_succeeds_for_the_mints_transfer_hook_authority() {
+    let (mut svm, admin_kp) = setup();
+    let admin_pk = admin_kp.pubkey();
+    let (mint_pk, meta_list) = setup_mint(&mut svm, &admin_kp);
+
+    // Fresh mints already get the current (2-entry) layout, so this is the
+    // idempotent case: resizing to the same size and rewriting identical
+    // content must still succeed and leave a well-formed account behind.
+    let before = svm.get_account(&meta_list).unwrap().data;
+    assert_eq!(before.len(), abl_token::get_meta_list_size().unwrap());
+
+    let resize_ix = abl_token::instruction::ResizeMetaList {};
+    let resize_accounts = ResizeMetaList {
+        payer: admin_pk,
+        mint: mint_pk,
+        extra_metas_account: meta_list,
+        system_program: SYSTEM_PROGRAM_ID,
+        token_program: TOKEN_22_PROGRAM_ID,
+    };
+    let instruction = Instruction {
+        program_id: PROGRAM_ID,
+        accounts: resize_accounts.to_account_metas(None),
+        data: resize_ix.data(),
+    };
+    let msg = Message::new(&[instruction], Some(&admin_pk));
+    let tx = Transaction::new(&[&admin_kp], msg, svm.latest_blockhash());
+
+    svm.send_transaction(tx).unwrap();
+
+    let after = svm.get_account(&meta_list).unwrap().data;
+    assert_eq!(after.len(), abl_token::get_meta_list_size().unwrap());
+    assert_eq!(after, before);
+}
+
+#[test]
+fn resize_meta_list_rejects_a_non_authority_signer() {
+    let (mut svm, admin_kp) = setup();
+    let (mint_pk, meta_list) = setup_mint(&mut svm, &admin_kp);
+
+    let attacker_kp = Keypair::new();
+    let attacker_pk = attacker_kp.pubkey();
+    svm.airdrop(&attacker_pk, 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Anyone can pay for the resize, but the CPI back into Token-2022's
+    // `update_transfer_hook` only succeeds if the signer is the mint's real
+    // transfer-hook authority (`admin_pk`, not `attacker_pk`) - that's what
+    // gates this instruction, since it has no authority table of its own.
+    let resize_ix = abl_token::instruction::ResizeMetaList {};
+    let resize_accounts = ResizeMetaList {
+        payer: attacker_pk,
+        mint: mint_pk,
+        extra_metas_account: meta_list,
+        system_program: SYSTEM_PROGRAM_ID,
+        token_program: TOKEN_22_PROGRAM_ID,
+    };
+    let instruction = Instruction {
+        program_id: PROGRAM_ID,
+        accounts: resize_accounts.to_account_metas(None),
+        data: resize_ix.data(),
+    };
+    let msg = Message::new(&[instruction], Some(&attacker_pk));
+    let tx = Transaction::new(&[&attacker_kp], msg, svm.latest_blockhash());
+
+    let res = svm.send_transaction(tx);
+    assert!(res.is_err(), "a non-authority signer must not be able to resize another mint's meta list");
+}
+
+#[test]
+fn resize_meta_list_migrates_a_mint_created_under_the_old_one_entry_layout() {
+    let (mut svm, admin_kp) = setup();
+    let admin_pk = admin_kp.pubkey();
+    let (mint_pk, meta_list) = setup_mint(&mut svm, &admin_kp);
+
+    // Overwrite the freshly-created (already-correct, 2-entry) meta list with
+    // what a mint set up under the *old* program would actually have on
+    // chain: a single entry resolving only the destination wallet. This is
+    // the exact stale state Greptile flagged - upgrading the program alone
+    // doesn't rewrite already-initialized accounts.
+    let old_metas = vec![ExtraAccountMeta::new_with_seeds(
+        &[
+            Seed::Literal { bytes: b"ab_wallet".to_vec() },
+            Seed::AccountData { account_index: 2, data_index: 32, length: 32 },
+        ],
+        false,
+        false,
+    )
+    .unwrap()];
+    let old_size = ExtraAccountMetaList::size_of(old_metas.len()).unwrap();
+    let mut old_data = vec![0u8; old_size];
+    ExtraAccountMetaList::init::<ExecuteInstruction>(&mut old_data, &old_metas).unwrap();
+
+    let current_account = svm.get_account(&meta_list).unwrap();
+    svm.set_account(
+        meta_list,
+        Account {
+            lamports: svm.minimum_balance_for_rent_exemption(old_size),
+            data: old_data,
+            ..current_account
+        },
+    )
+    .unwrap();
+    assert_eq!(svm.get_account(&meta_list).unwrap().data.len(), old_size);
+
+    let resize_ix = abl_token::instruction::ResizeMetaList {};
+    let resize_accounts = ResizeMetaList {
+        payer: admin_pk,
+        mint: mint_pk,
+        extra_metas_account: meta_list,
+        system_program: SYSTEM_PROGRAM_ID,
+        token_program: TOKEN_22_PROGRAM_ID,
+    };
+    let instruction = Instruction {
+        program_id: PROGRAM_ID,
+        accounts: resize_accounts.to_account_metas(None),
+        data: resize_ix.data(),
+    };
+    let msg = Message::new(&[instruction], Some(&admin_pk));
+    let tx = Transaction::new(&[&admin_kp], msg, svm.latest_blockhash());
+    svm.send_transaction(tx).unwrap();
+
+    let new_size = abl_token::get_meta_list_size().unwrap();
+    let mut expected_data = vec![0u8; new_size];
+    ExtraAccountMetaList::init::<ExecuteInstruction>(
+        &mut expected_data,
+        &abl_token::get_extra_account_metas().unwrap(),
+    )
+    .unwrap();
+
+    let migrated = svm.get_account(&meta_list).unwrap();
+    assert_eq!(migrated.data.len(), new_size, "meta list must be resized to the current 2-entry layout");
+    assert_eq!(migrated.data, expected_data, "migrated meta list must match a freshly-initialized one exactly");
 }
 
 fn derive_config() -> Pubkey {

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/src/components/account/account-data-access.tsx
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/src/components/account/account-data-access.tsx
@@ -83,10 +83,17 @@ export function useSendTokens() {
             if (!transferHook) throw new Error('bad token');
             const extraMetas = getExtraAccountMetaAddress(mint, transferHook.programId);
 
-            const seeds = [Buffer.from('ab_wallet'), destination.toBuffer()];
-            const abWallet = PublicKey.findProgramAddressSync(seeds, transferHook.programId)[0];
+            // The hook checks both the sender and the receiver's allow/block
+            // status - the account order here must match the program's
+            // get_extra_account_metas() (source first, then destination).
+            const sourceSeeds = [Buffer.from('ab_wallet'), publicKey.toBuffer()];
+            const sourceAbWallet = PublicKey.findProgramAddressSync(sourceSeeds, transferHook.programId)[0];
 
-            ix3.keys.push({ pubkey: abWallet, isSigner: false, isWritable: false });
+            const destinationSeeds = [Buffer.from('ab_wallet'), destination.toBuffer()];
+            const destinationAbWallet = PublicKey.findProgramAddressSync(destinationSeeds, transferHook.programId)[0];
+
+            ix3.keys.push({ pubkey: sourceAbWallet, isSigner: false, isWritable: false });
+            ix3.keys.push({ pubkey: destinationAbWallet, isSigner: false, isWritable: false });
             ix3.keys.push({
                 pubkey: transferHook.programId,
                 isSigner: false,


### PR DESCRIPTION
## Summary

`allow-block-list-token`'s transfer hook only ever checked the **destination** wallet's allow/block status. A wallet explicitly blocked via `init_wallet` (`ABWallet { allowed: false }`) could still send its entire balance out through an ordinary `TransferChecked` to any unlisted destination — in every mint mode (Allow/Block/Threshold), since the sender's `ABWallet` record was never read at all.

This directly contradicts the `WalletBlocked` error name and the "Blocked" badge shown in the admin UI, and defeats the standard real-world reason to build a block-list token (e.g. sanctions compliance: stopping the sanctioned party from moving funds *out*).

**Root cause:** `utils.rs`'s `get_extra_account_metas()` configured exactly one extra account for the hook's `Execute` call, seeded from `account_index: 2` (the destination token account). `tx_hook.rs` had a `source_token_account` field on the accounts struct but never read it — the decision logic never had access to the sender's status in any mode.

## Fix

- `utils.rs` — add a second extra account seeded from the source token account's owner (`account_index: 0`), so Token-2022 resolves and appends both the source's and destination's `ab_wallet` PDAs to every `Execute` CPI.
- `tx_hook.rs` — add `source_ab_wallet` to the `TxHook` accounts struct (ordered to match `get_extra_account_metas()`), and extend the decision logic so a wallet with an explicit `allowed: false` record is rejected regardless of which side of the transfer it's on. Allow/Threshold mode's documented "who may *receive*" semantics (see this example's README) are left untouched — only the block-list's own "blocked" concept, whose name and UI already imply full blocking, becomes bidirectional.
- The decision matrix is pulled out into a standalone `decide(mint_mode, source_mode, destination_mode, amount)` function with unit tests, since this program has no integration-test harness that exercises `tx_hook` via a real hooked transfer (`tests/test.rs` only covers `init_config`/`init_mint`).
- `src/components/account/account-data-access.tsx` — the demo frontend's `useSendTokens()` manually constructs the hook's extra accounts rather than relying on Token-2022's standard client-side auto-resolution. Updated it to push both the source and destination `ab_wallet` PDAs, in the same order the program now expects, so the demo UI stays consistent with the hardened program. This is a demo-consistency fix, not itself security-critical — any standards-conformant Token-2022 client picks up the corrected on-chain `ExtraAccountMetaList` automatically. Not verified via live browser/wallet testing (no validator available in this environment); it's a direct structural mirror of the pre-existing destination-account push, keyed on the sender's own public key instead.

## Out of scope

`block-list/pinocchio` (a separate, unrelated example) has a self-documented limitation in its own README where setting up the `ExtraAccountMetaList` while the block list is still empty locks in "0 extra accounts" until `setup-extra-metas` is manually re-run after the first block. Lower severity (requires operator error, not silently wrong-by-design) and a different program — worth a follow-up PR, not bundled here.

## Test plan

- [x] `cargo check` — `abl-token` compiles clean with the new account and function signature.
- [x] `cargo test --lib` — 9/9 pass, including the new `decide()` unit tests covering both sides of the block check and the existing Allow/Block/Threshold semantics.
- [x] Verified the key test actually catches the original bug: temporarily reintroduced the old (destination-only) logic and confirmed `source_blocked_is_always_rejected` fails against it, then confirmed all 9 tests pass again against the fix.
- [x] `anchor build` — IDL regenerates with exactly 7 accounts for `tx_hook`, in the order Token-2022 will actually append them.
- [x] `pnpm exec tsc --noEmit` on the frontend — clean, no type errors from the `account-data-access.tsx` change.
- [x] `pnpm run lint` / `pnpm run format:check` — clean (pre-existing warnings/diffs in untouched files left as-is).
- [ ] Live end-to-end test of the frontend send flow against a real validator (not available in this environment).