### PR TITLE
security: fix inverted fundraiser deadline logic in token-fundraiser

### DIFF
--- a/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/contribute.rs
+++ b/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/contribute.rs
@@ -68,10 +68,10 @@ impl<'info> Contribute<'info> {
             FundraiserError::ContributionTooBig
         );
 
-        // Check if the fundraising duration has been reached
+        // Check that the fundraising duration has not elapsed yet
         let current_time = Clock::get()?.unix_timestamp;
         require!(
-            self.fundraiser.duration <= ((current_time - self.fundraiser.time_started) / SECONDS_TO_DAYS) as u16,
+            self.fundraiser.duration > ((current_time - self.fundraiser.time_started) / SECONDS_TO_DAYS) as u16,
             crate::FundraiserError::FundraiserEnded
         );
 

--- a/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/refund.rs
+++ b/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/refund.rs
@@ -54,11 +54,11 @@ pub struct Refund<'info> {
 impl<'info> Refund<'info> {
     pub fn refund(&mut self) -> Result<()> {
 
-        // Check if the fundraising duration has been reached
+        // Check that the fundraising duration has elapsed
         let current_time = Clock::get()?.unix_timestamp;
- 
+
         require!(
-            self.fundraiser.duration >= ((current_time - self.fundraiser.time_started) / SECONDS_TO_DAYS) as u16,
+            self.fundraiser.duration <= ((current_time - self.fundraiser.time_started) / SECONDS_TO_DAYS) as u16,
             crate::FundraiserError::FundraiserNotEnded
         );
 

--- a/tokens/token-fundraiser/anchor/readme.MD
+++ b/tokens/token-fundraiser/anchor/readme.MD
@@ -212,10 +212,10 @@ impl<'info> Contribute<'info> {
             FundraiserError::MaximumContributionsReached
         );
 
-        // Check if the fundraising duration has been reached
+        // Check that the fundraising duration has not elapsed yet
         let current_time = Clock::get()?.unix_timestamp;
         require!(
-            self.fundraiser.duration <= ((current_time - self.fundraiser.time_started) / SECONDS_TO_DAYS) as u8,
+            self.fundraiser.duration > ((current_time - self.fundraiser.time_started) / SECONDS_TO_DAYS) as u8,
             crate::FundraiserError::FundraisingEnded
         );
 

--- a/tokens/token-fundraiser/anchor/tests/fundraiser.ts
+++ b/tokens/token-fundraiser/anchor/tests/fundraiser.ts
@@ -10,7 +10,23 @@ import {
     TOKEN_PROGRAM_ID,
 } from '@solana/spl-token';
 import BN from 'bn.js';
+import { assert } from 'chai';
 import type { Fundraiser } from '../target/types/fundraiser';
+
+// Asserts that `promise` rejects with the given Anchor custom error code (e.g.
+// 'FundraiserNotEnded'), not just "something failed" - a promise that fails
+// for an unrelated reason (wrong seeds, missing account) would otherwise pass
+// just as easily as the specific check we actually mean to be testing.
+const expectAnchorError = async (promise: Promise<unknown>, code: string) => {
+    let caught: any;
+    try {
+        await promise;
+    } catch (error) {
+        caught = error;
+    }
+    assert.isDefined(caught, `expected the transaction to fail with ${code}`);
+    assert.strictEqual(caught?.error?.errorCode?.code, code, `expected ${code}, got: ${caught}`);
+};
 
 describe('fundraiser', () => {
     // Configure the client to use the local cluster.
@@ -78,8 +94,13 @@ describe('fundraiser', () => {
     it('Initialize Fundaraiser', async () => {
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
+        // duration=1 (day). This suite runs against a real validator with no
+        // way to fast-forward its clock, so it can only ever exercise "still
+        // within the window" (contribute succeeds, refund correctly rejects)
+        // - the post-deadline happy path is covered in litesvm.test.ts,
+        // which CAN warp its clock deterministically.
         const tx = await program.methods
-            .initialize(new BN(30000000), 0)
+            .initialize(new BN(30000000), 1)
             .accountsPartial({
                 maker: maker.publicKey,
                 fundraiser,
@@ -145,10 +166,13 @@ describe('fundraiser', () => {
     });
 
     it('Contribute to Fundraiser - Robustness Test', async () => {
-        try {
-            const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
+        // Contributor already holds 2_000_000, and the per-contributor cap is
+        // 10% of the 30_000_000 target = 3_000_000. This 2_000_000 attempt
+        // would push the total to 4_000_000, over the cap.
+        const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
-            const tx = await program.methods
+        await expectAnchorError(
+            program.methods
                 .contribute(new BN(2000000))
                 .accountsPartial({
                     contributor: provider.publicKey,
@@ -159,22 +183,17 @@ describe('fundraiser', () => {
                     tokenProgram: TOKEN_PROGRAM_ID,
                 })
                 .rpc()
-                .then(confirm);
-
-            console.log('\nContributed to fundraiser', tx);
-            console.log('Your transaction signature', tx);
-            console.log('Vault balance', (await provider.connection.getTokenAccountBalance(vault)).value.amount);
-        } catch (error) {
-            console.log('\nError contributing to fundraiser');
-            console.log(error.msg);
-        }
+                .then(confirm),
+            'MaximumContributionsReached',
+        );
     });
 
     it('Check contributions - Robustness Test', async () => {
-        try {
-            const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
+        // Only 2_000_000 has been contributed against a 30_000_000 target.
+        const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
-            const tx = await program.methods
+        await expectAnchorError(
+            program.methods
                 .checkContributions()
                 .accountsPartial({
                     maker: maker.publicKey,
@@ -186,41 +205,48 @@ describe('fundraiser', () => {
                 })
                 .signers([maker])
                 .rpc()
-                .then(confirm);
-
-            console.log('\nChecked contributions');
-            console.log('Your transaction signature', tx);
-            console.log('Vault balance', (await provider.connection.getTokenAccountBalance(vault)).value.amount);
-        } catch (error) {
-            console.log('\nError checking contributions');
-            console.log(error.msg);
-        }
+                .then(confirm),
+            'TargetNotMet',
+        );
     });
 
-    it('Refund Contributions', async () => {
+    // This suite runs against a real solana-test-validator, which has no way
+    // to fast-forward its clock, so it can't exercise "refund succeeds once
+    // the deadline has passed" - see litesvm.test.ts for that happy path
+    // (and for a direct, isolated repro of the "contribute only works past
+    // the deadline" half of the original bug, at the exact boundary).
+    // What this test verifies without any time travel: a refund attempted
+    // while the fundraiser is still genuinely active must be rejected, and
+    // must not move any funds. Pre-fix this call actually fails with
+    // AccountNotInitialized rather than a wrongly-succeeding refund - with a
+    // realistic nonzero duration, contribute() was broken from its very
+    // first call, so no Contributor account was ever created for refund to
+    // act on. Same root cause, different symptom; either way this only
+    // passes once refund is correctly gated on FundraiserNotEnded.
+    it('Refund is rejected while the fundraiser is still active', async () => {
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
+        const vaultBalanceBefore = (await provider.connection.getTokenAccountBalance(vault)).value.amount;
 
-        const contributorAccount = await program.account.contributor.fetch(contributor);
-        console.log('\nContributor balance', contributorAccount.amount.toString());
+        await expectAnchorError(
+            program.methods
+                .refund()
+                .accountsPartial({
+                    contributor: provider.publicKey,
+                    maker: maker.publicKey,
+                    mintToRaise: mint,
+                    fundraiser,
+                    contributorAccount: contributor,
+                    contributorAta: contributorATA,
+                    vault,
+                    tokenProgram: TOKEN_PROGRAM_ID,
+                    systemProgram: anchor.web3.SystemProgram.programId,
+                })
+                .rpc()
+                .then(confirm),
+            'FundraiserNotEnded',
+        );
 
-        const tx = await program.methods
-            .refund()
-            .accountsPartial({
-                contributor: provider.publicKey,
-                maker: maker.publicKey,
-                mintToRaise: mint,
-                fundraiser,
-                contributorAccount: contributor,
-                contributorAta: contributorATA,
-                vault,
-                tokenProgram: TOKEN_PROGRAM_ID,
-                systemProgram: anchor.web3.SystemProgram.programId,
-            })
-            .rpc()
-            .then(confirm);
-
-        console.log('\nRefunded contributions', tx);
-        console.log('Your transaction signature', tx);
-        console.log('Vault balance', (await provider.connection.getTokenAccountBalance(vault)).value.amount);
+        const vaultBalanceAfter = (await provider.connection.getTokenAccountBalance(vault)).value.amount;
+        assert.strictEqual(vaultBalanceAfter, vaultBalanceBefore, 'rejected refund must not move any funds');
     });
 });

--- a/tokens/token-fundraiser/anchor/tests/fundraiser.ts
+++ b/tokens/token-fundraiser/anchor/tests/fundraiser.ts
@@ -12,21 +12,7 @@ import {
 import BN from 'bn.js';
 import { assert } from 'chai';
 import type { Fundraiser } from '../target/types/fundraiser';
-
-// Asserts that `promise` rejects with the given Anchor custom error code (e.g.
-// 'FundraiserNotEnded'), not just "something failed" - a promise that fails
-// for an unrelated reason (wrong seeds, missing account) would otherwise pass
-// just as easily as the specific check we actually mean to be testing.
-const expectAnchorError = async (promise: Promise<unknown>, code: string) => {
-    let caught: any;
-    try {
-        await promise;
-    } catch (error) {
-        caught = error;
-    }
-    assert.isDefined(caught, `expected the transaction to fail with ${code}`);
-    assert.strictEqual(caught?.error?.errorCode?.code, code, `expected ${code}, got: ${caught}`);
-};
+import { expectAnchorError } from './utils';
 
 describe('fundraiser', () => {
     // Configure the client to use the local cluster.
@@ -94,11 +80,8 @@ describe('fundraiser', () => {
     it('Initialize Fundaraiser', async () => {
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
-        // duration=1 (day). This suite runs against a real validator with no
-        // way to fast-forward its clock, so it can only ever exercise "still
-        // within the window" (contribute succeeds, refund correctly rejects)
-        // - the post-deadline happy path is covered in litesvm.test.ts,
-        // which CAN warp its clock deterministically.
+        // duration=1 day. No clock-warping here (real validator) - the
+        // post-deadline happy path is covered in litesvm.test.ts instead.
         const tx = await program.methods
             .initialize(new BN(30000000), 1)
             .accountsPartial({
@@ -166,9 +149,8 @@ describe('fundraiser', () => {
     });
 
     it('Contribute to Fundraiser - Robustness Test', async () => {
-        // Contributor already holds 2_000_000, and the per-contributor cap is
-        // 10% of the 30_000_000 target = 3_000_000. This 2_000_000 attempt
-        // would push the total to 4_000_000, over the cap.
+        // Per-contributor cap is 10% of target (3_000_000); contributor
+        // already holds 2_000_000, so this pushes past the cap.
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
         await expectAnchorError(
@@ -210,19 +192,9 @@ describe('fundraiser', () => {
         );
     });
 
-    // This suite runs against a real solana-test-validator, which has no way
-    // to fast-forward its clock, so it can't exercise "refund succeeds once
-    // the deadline has passed" - see litesvm.test.ts for that happy path
-    // (and for a direct, isolated repro of the "contribute only works past
-    // the deadline" half of the original bug, at the exact boundary).
-    // What this test verifies without any time travel: a refund attempted
-    // while the fundraiser is still genuinely active must be rejected, and
-    // must not move any funds. Pre-fix this call actually fails with
-    // AccountNotInitialized rather than a wrongly-succeeding refund - with a
-    // realistic nonzero duration, contribute() was broken from its very
-    // first call, so no Contributor account was ever created for refund to
-    // act on. Same root cause, different symptom; either way this only
-    // passes once refund is correctly gated on FundraiserNotEnded.
+    // Can't clock-warp on a real validator, so this only proves refund is
+    // rejected while active - see litesvm.test.ts for the post-deadline
+    // happy path.
     it('Refund is rejected while the fundraiser is still active', async () => {
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
         const vaultBalanceBefore = (await provider.connection.getTokenAccountBalance(vault)).value.amount;

--- a/tokens/token-fundraiser/anchor/tests/litesvm.test.ts
+++ b/tokens/token-fundraiser/anchor/tests/litesvm.test.ts
@@ -12,11 +12,27 @@ import {
 import { PublicKey } from '@solana/web3.js';
 import { LiteSVMProvider } from 'anchor-litesvm';
 import BN from 'bn.js';
+import { assert } from 'chai';
 import { LiteSVM } from 'litesvm';
 import IDL from '../target/idl/fundraiser.json';
 import type { Fundraiser } from '../target/types/fundraiser';
 
 const PROGRAM_ID = new PublicKey(IDL.address);
+const SECONDS_PER_DAY = 86400n;
+
+// Asserts that `promise` rejects with the given Anchor custom error code
+// (e.g. 'FundraiserNotEnded'), not just "something failed" - see the same
+// helper in tests/fundraiser.ts for why this matters.
+const expectAnchorError = async (promise: Promise<unknown>, code: string) => {
+    let caught: any;
+    try {
+        await promise;
+    } catch (error) {
+        caught = error;
+    }
+    assert.isDefined(caught, `expected the transaction to fail with ${code}`);
+    assert.strictEqual(caught?.error?.errorCode?.code, code, `expected ${code}, got: ${caught}`);
+};
 
 describe('fundraiser litesvm', () => {
     const client = new LiteSVM();
@@ -78,8 +94,13 @@ describe('fundraiser litesvm', () => {
     it('Initialize Fundaraiser', async () => {
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
+        // duration=1 (day). Unlike fundraiser.ts, this suite can warp its
+        // own clock deterministically, so it covers the full lifecycle:
+        // contribute while active, refund rejected while active, contribute
+        // rejected once the deadline passes, and refund succeeding once it
+        // has (see the tests below, in that order).
         const tx = await program.methods
-            .initialize(new BN(30000000), 0)
+            .initialize(new BN(30000000), 1)
             .accountsPartial({
                 maker: maker.publicKey,
                 fundraiser,
@@ -143,10 +164,16 @@ describe('fundraiser litesvm', () => {
     });
 
     it('Contribute to Fundraiser - Robustness Test', async () => {
-        try {
-            const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
+        // Contributor already holds 2_000_000, and the per-contributor cap
+        // is 10% of the 30_000_000 target = 3_000_000. This 2_000_000
+        // attempt would push the total to 4_000_000, over the cap. Must run
+        // before the deadline warp below - once the deadline passes,
+        // contribute() rejects on the time check first, which would test
+        // the wrong thing.
+        const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
-            const tx = await program.methods
+        await expectAnchorError(
+            program.methods
                 .contribute(new BN(2000000))
                 .accountsPartial({
                     contributor: provider.publicKey,
@@ -156,22 +183,55 @@ describe('fundraiser litesvm', () => {
                     vault,
                     tokenProgram: TOKEN_PROGRAM_ID,
                 })
-                .rpc();
+                .rpc(),
+            'MaximumContributionsReached',
+        );
+    });
 
-            console.log('\nContributed to fundraiser', tx);
-            console.log('Your transaction signature', tx);
-            console.log('Vault balance', tokenBalance(vault).toString());
-        } catch (error) {
-            console.log('\nError contributing to fundraiser');
-            console.log(error.msg);
-        }
+    // Confirms refund() is correctly gated on FundraiserNotEnded while the
+    // fundraiser is genuinely still active. Note this doesn't reproduce the
+    // original bug in isolation: with a realistic nonzero duration,
+    // contribute() itself was broken from the very first call (see the
+    // "Fundraiser closes..." test below for a direct, isolated repro of
+    // that half), so pre-fix this call actually fails with
+    // AccountNotInitialized instead (no Contributor account ever got
+    // created) - a different symptom of the same root cause, not the
+    // "refund wrongly succeeds" behavior that specifically required the
+    // original tests' degenerate duration=0 setup. Either way, this only
+    // passes once refund is correctly gated on FundraiserNotEnded
+    // specifically, so it still fails before the fix and passes after.
+    it('Refund is rejected while the fundraiser is still active', async () => {
+        const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
+        const vaultBalanceBefore = tokenBalance(vault);
+
+        await expectAnchorError(
+            program.methods
+                .refund()
+                .accountsPartial({
+                    contributor: provider.publicKey,
+                    maker: maker.publicKey,
+                    mintToRaise: mint,
+                    fundraiser,
+                    contributorAccount: contributor,
+                    contributorAta: contributorATA,
+                    vault,
+                    tokenProgram: TOKEN_PROGRAM_ID,
+                    systemProgram: anchor.web3.SystemProgram.programId,
+                })
+                .rpc(),
+            'FundraiserNotEnded',
+        );
+
+        assert.strictEqual(tokenBalance(vault), vaultBalanceBefore, 'rejected refund must not move any funds');
     });
 
     it('Check contributions - Robustness Test', async () => {
-        try {
-            const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
+        // Only 2_000_000 has been contributed against a 30_000_000 target.
+        // Time-independent - checker.rs has no duration check.
+        const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
-            const tx = await program.methods
+        await expectAnchorError(
+            program.methods
                 .checkContributions()
                 .accountsPartial({
                     maker: maker.publicKey,
@@ -182,22 +242,67 @@ describe('fundraiser litesvm', () => {
                     tokenProgram: TOKEN_PROGRAM_ID,
                 })
                 .signers([maker])
-                .rpc();
+                .rpc(),
+            'TargetNotMet',
+        );
+    });
 
-            console.log('\nChecked contributions');
-            console.log('Your transaction signature', tx);
-            console.log('Vault balance', tokenBalance(vault).toString());
-        } catch (error) {
-            console.log('\nError checking contributions');
-            console.log(error.msg);
-        }
+    // This is the other half of the original bug: contribute() used to only
+    // succeed AFTER the deadline (backwards). Warp to the exact boundary
+    // (elapsed_days == duration) rather than some point further out, so this
+    // pins the boundary itself - a boundary that's off by one in either
+    // direction would flip this test's result.
+    it('Fundraiser closes to contributions once the duration has elapsed', async () => {
+        const fundraiserAccount = await program.account.fundraiser.fetch(fundraiser);
+        const deadline =
+            BigInt(fundraiserAccount.timeStarted.toString()) + BigInt(fundraiserAccount.duration) * SECONDS_PER_DAY;
+
+        const clock = client.getClock();
+        clock.unixTimestamp = deadline;
+        client.setClock(clock);
+        // Without this, the next contribute() call would build a
+        // byte-identical transaction to an earlier one (same instruction,
+        // accounts, and fee payer) and get silently rejected as
+        // already-processed rather than actually being evaluated.
+        client.expireBlockhash();
+
+        const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
+
+        // 1_000_000, not 2_000_000: the contributor holds 2_000_000 already
+        // and the per-contributor cap is 3_000_000, so 2_000_000 would hit
+        // MaximumContributionsReached regardless of the time check - that
+        // would make this test pass whether or not the deadline fix is
+        // present. 1_000_000 keeps the cap check passing
+        // (2_000_000 + 1_000_000 = 3_000_000 <= 3_000_000), so the time
+        // check is the only thing that can reject it.
+        await expectAnchorError(
+            program.methods
+                .contribute(new BN(1000000))
+                .accountsPartial({
+                    contributor: provider.publicKey,
+                    fundraiser,
+                    contributorAccount: contributor,
+                    contributorAta: contributorATA,
+                    vault,
+                    tokenProgram: TOKEN_PROGRAM_ID,
+                })
+                .rpc(),
+            'FundraiserEnded',
+        );
     });
 
     it('Refund Contributions', async () => {
+        // Runs after the deadline warp above, so elapsed_days (1) >=
+        // duration (1) now holds and the target (30_000_000) was never met
+        // (only 2_000_000 was ever contributed) - the intended happy path.
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
         const contributorAccount = await program.account.contributor.fetch(contributor);
         console.log('\nContributor balance', contributorAccount.amount.toString());
+
+        // Same instruction/accounts/fee-payer shape as the earlier rejected
+        // refund attempt - same duplicate-transaction hazard as above.
+        client.expireBlockhash();
 
         const tx = await program.methods
             .refund()
@@ -216,6 +321,13 @@ describe('fundraiser litesvm', () => {
 
         console.log('\nRefunded contributions', tx);
         console.log('Your transaction signature', tx);
-        console.log('Vault balance', tokenBalance(vault).toString());
+
+        assert.strictEqual(tokenBalance(vault), 0n, 'vault should be fully drained back to the contributor');
+        assert.strictEqual(
+            tokenBalance(contributorATA),
+            10_000_000n,
+            "contributor's full original balance should be restored",
+        );
+        assert.isNull(client.getAccount(contributor), 'the Contributor account should be closed');
     });
 });

--- a/tokens/token-fundraiser/anchor/tests/litesvm.test.ts
+++ b/tokens/token-fundraiser/anchor/tests/litesvm.test.ts
@@ -16,23 +16,10 @@ import { assert } from 'chai';
 import { LiteSVM } from 'litesvm';
 import IDL from '../target/idl/fundraiser.json';
 import type { Fundraiser } from '../target/types/fundraiser';
+import { expectAnchorError } from './utils';
 
 const PROGRAM_ID = new PublicKey(IDL.address);
 const SECONDS_PER_DAY = 86400n;
-
-// Asserts that `promise` rejects with the given Anchor custom error code
-// (e.g. 'FundraiserNotEnded'), not just "something failed" - see the same
-// helper in tests/fundraiser.ts for why this matters.
-const expectAnchorError = async (promise: Promise<unknown>, code: string) => {
-    let caught: any;
-    try {
-        await promise;
-    } catch (error) {
-        caught = error;
-    }
-    assert.isDefined(caught, `expected the transaction to fail with ${code}`);
-    assert.strictEqual(caught?.error?.errorCode?.code, code, `expected ${code}, got: ${caught}`);
-};
 
 describe('fundraiser litesvm', () => {
     const client = new LiteSVM();
@@ -94,11 +81,8 @@ describe('fundraiser litesvm', () => {
     it('Initialize Fundaraiser', async () => {
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
-        // duration=1 (day). Unlike fundraiser.ts, this suite can warp its
-        // own clock deterministically, so it covers the full lifecycle:
-        // contribute while active, refund rejected while active, contribute
-        // rejected once the deadline passes, and refund succeeding once it
-        // has (see the tests below, in that order).
+        // duration=1 day. This suite can warp its own clock, so it covers
+        // the full lifecycle (see the tests below).
         const tx = await program.methods
             .initialize(new BN(30000000), 1)
             .accountsPartial({
@@ -164,12 +148,8 @@ describe('fundraiser litesvm', () => {
     });
 
     it('Contribute to Fundraiser - Robustness Test', async () => {
-        // Contributor already holds 2_000_000, and the per-contributor cap
-        // is 10% of the 30_000_000 target = 3_000_000. This 2_000_000
-        // attempt would push the total to 4_000_000, over the cap. Must run
-        // before the deadline warp below - once the deadline passes,
-        // contribute() rejects on the time check first, which would test
-        // the wrong thing.
+        // Per-contributor cap is 3_000_000 (10% of target); contributor
+        // holds 2_000_000 already. Must run before the deadline warp below.
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
         await expectAnchorError(
@@ -188,18 +168,9 @@ describe('fundraiser litesvm', () => {
         );
     });
 
-    // Confirms refund() is correctly gated on FundraiserNotEnded while the
-    // fundraiser is genuinely still active. Note this doesn't reproduce the
-    // original bug in isolation: with a realistic nonzero duration,
-    // contribute() itself was broken from the very first call (see the
-    // "Fundraiser closes..." test below for a direct, isolated repro of
-    // that half), so pre-fix this call actually fails with
-    // AccountNotInitialized instead (no Contributor account ever got
-    // created) - a different symptom of the same root cause, not the
-    // "refund wrongly succeeds" behavior that specifically required the
-    // original tests' degenerate duration=0 setup. Either way, this only
-    // passes once refund is correctly gated on FundraiserNotEnded
-    // specifically, so it still fails before the fix and passes after.
+    // Pre-fix this fails with AccountNotInitialized, not a wrongly-
+    // succeeding refund - contribute() was broken from its first call, so
+    // no Contributor account ever formed. Same bug, different symptom.
     it('Refund is rejected while the fundraiser is still active', async () => {
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
         const vaultBalanceBefore = tokenBalance(vault);
@@ -247,11 +218,8 @@ describe('fundraiser litesvm', () => {
         );
     });
 
-    // This is the other half of the original bug: contribute() used to only
-    // succeed AFTER the deadline (backwards). Warp to the exact boundary
-    // (elapsed_days == duration) rather than some point further out, so this
-    // pins the boundary itself - a boundary that's off by one in either
-    // direction would flip this test's result.
+    // Warps to the exact deadline boundary (not past it) to pin the
+    // off-by-one directly: contribute must reject exactly here.
     it('Fundraiser closes to contributions once the duration has elapsed', async () => {
         const fundraiserAccount = await program.account.fundraiser.fetch(fundraiser);
         const deadline =
@@ -260,21 +228,13 @@ describe('fundraiser litesvm', () => {
         const clock = client.getClock();
         clock.unixTimestamp = deadline;
         client.setClock(clock);
-        // Without this, the next contribute() call would build a
-        // byte-identical transaction to an earlier one (same instruction,
-        // accounts, and fee payer) and get silently rejected as
-        // already-processed rather than actually being evaluated.
+        // Avoids a duplicate-transaction rejection from an earlier identical call.
         client.expireBlockhash();
 
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
-        // 1_000_000, not 2_000_000: the contributor holds 2_000_000 already
-        // and the per-contributor cap is 3_000_000, so 2_000_000 would hit
-        // MaximumContributionsReached regardless of the time check - that
-        // would make this test pass whether or not the deadline fix is
-        // present. 1_000_000 keeps the cap check passing
-        // (2_000_000 + 1_000_000 = 3_000_000 <= 3_000_000), so the time
-        // check is the only thing that can reject it.
+        // 1_000_000 keeps the per-contributor cap check passing, so only
+        // the time check can reject this - proving it's the deadline.
         await expectAnchorError(
             program.methods
                 .contribute(new BN(1000000))
@@ -292,16 +252,13 @@ describe('fundraiser litesvm', () => {
     });
 
     it('Refund Contributions', async () => {
-        // Runs after the deadline warp above, so elapsed_days (1) >=
-        // duration (1) now holds and the target (30_000_000) was never met
-        // (only 2_000_000 was ever contributed) - the intended happy path.
+        // Runs after the deadline warp above, so refund's time check now passes.
         const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
 
         const contributorAccount = await program.account.contributor.fetch(contributor);
         console.log('\nContributor balance', contributorAccount.amount.toString());
 
-        // Same instruction/accounts/fee-payer shape as the earlier rejected
-        // refund attempt - same duplicate-transaction hazard as above.
+        // Same duplicate-transaction hazard as above.
         client.expireBlockhash();
 
         const tx = await program.methods

--- a/tokens/token-fundraiser/anchor/tests/utils.ts
+++ b/tokens/token-fundraiser/anchor/tests/utils.ts
@@ -1,0 +1,14 @@
+import { assert } from 'chai';
+
+// Asserts `promise` rejects with the given Anchor custom error code, not
+// just "something failed".
+export const expectAnchorError = async (promise: Promise<unknown>, code: string) => {
+    let caught: any;
+    try {
+        await promise;
+    } catch (error) {
+        caught = error;
+    }
+    assert.isDefined(caught, `expected the transaction to fail with ${code}`);
+    assert.strictEqual(caught?.error?.errorCode?.code, code, `expected ${code}, got: ${caught}`);
+};


### PR DESCRIPTION
## Summary

`token-fundraiser`'s time-based access control is inverted, breaking the program's core promise (contribute while active, refund if the goal isn't met by the deadline) and permanently locking contributor funds in the realistic case.

**`contribute.rs`** required `duration <= elapsed_days` to pass — contributions only succeeded *after* the fundraiser's duration had already elapsed, staying open forever after that. While the fundraiser is genuinely "active," every contribution reverts with `FundraiserEnded` — the opposite of what that error name implies.

**`refund.rs`** required `duration >= elapsed_days` to pass — refunds only succeeded *before* the deadline. Once the deadline genuinely passes (exactly when `contribute()` *starts* working per the bug above), `refund()` stops working.

**Net effect:** with any realistic nonzero duration, `contribute()` and `refund()` are live in mutually-exclusive, backwards windows. Nobody can contribute while the fundraiser claims to be running; once contributions start flowing in (only possible post-deadline), refund is permanently blocked. If the target isn't met, funds sit in the vault with **no instruction able to move them** — `check_contributions` requires the target met, `refund` requires "not yet past deadline," which is now false by construction. A fund-lock, not a theft, but a complete break of the contract's core guarantee.

**Confirmed against intent, not just guessed:** the example's own `readme.MD` prose says contribute "checks that the fundraising duration has not elapsed" and refund is for "if the duration... has elapsed" — describing the correct behavior while the code implements the opposite. More directly: the README's refund code snippet *already has the correct form* — it's the actual `refund.rs` source that drifted from the README, not the other way around. The README's contribute snippet has the same inverted form as the real bug and needed the identical fix.

**Why no test caught this:** both test suites called `initialize(..., 0)` — duration=0. With duration=0, `elapsed_days >= 0` is always true, which trivially (and accidentally) satisfies *both* inverted checks at once, completely masking the inversion. The "robustness test" cases also swallowed errors without asserting anything.

## Fix

Minimal, two-character operator flips (not expression rewrites), so the diff mirrors the README's already-correct refund form:
- `contribute.rs`: `duration <= elapsed` → `duration > elapsed` (window still open).
- `refund.rs`: `duration >= elapsed` → `duration <= elapsed` (window has closed).
- `readme.MD`: same flip for the one inverted snippet (contribute section); the refund section was already correct, left untouched.
- Fixed the misleading comments above both checks ("Check if the fundraising duration has been reached" described neither direction correctly).

Verified boundary semantics precisely: at `elapsed_days == duration`, contribute must be closed and refund must be open — a deadline is an exclusive upper bound for contributing.

## Test changes

Both suites called `initialize(..., 0)`. Post-fix, `duration = 0` means "expired at creation" (was "never expires" pre-fix) — no validation exists on `duration` in `initialize`, so this is a real semantic change worth flagging, not just a test-parameter tweak. Both suites needed a realistic nonzero duration to exercise anything meaningful.

- **`tests/litesvm.test.ts`** (can deterministically warp its own clock): added a test that warps to the *exact* deadline boundary and confirms `contribute()` is rejected right at that instant (a direct, isolated repro of the "only works after the deadline" bug — this is the cleanest single proof that the fix is correct). Added a test confirming `refund()` is rejected while still active. Moved the existing happy-path refund test to run after the boundary warp, with stronger assertions (contributor ATA balance restored, vault drained to zero, `Contributor` account closed). Tightened the "robustness" tests to assert specific error codes instead of swallowing errors.
- **`tests/fundraiser.ts`** (real `solana-test-validator`, no way to fast-forward its clock — confirmed there's no RPC for it and `--warp-slot` is a startup-only flag that doesn't help mid-suite): restructured the final refund test into an assertion that refund is correctly rejected while still active, with a vault-balance-unchanged check. Tightened the two "robustness" tests the same way.

**Honesty note on test design:** with a realistic nonzero duration, `contribute()` was broken from its very first call pre-fix (confirmed by running the new tests against the unpatched code), so the "refund rejected while active" tests actually fail pre-fix via a *cascading* `AccountNotInitialized` (no `Contributor` account ever got created) rather than a direct "refund wrongly succeeds" repro — that specific symptom only reproduced under the original tests' degenerate `duration=0` setup. Both are still valid regression tests (fail before the fix, pass after with the specific intended error), and the litesvm boundary test independently and cleanly proves the `contribute()` half in isolation.

## Verification

Ran the full pre-fix/post-fix × old-tests/new-tests matrix locally (both suites, matching what `anchor test --validator legacy` runs in CI):
- Pre-fix + original tests (duration=0): all green — reproduces exactly how the masking happened.
- Pre-fix + new tests (duration=1): multiple independent failures, including the boundary test directly showing contribute() succeeding when it should have rejected.
- Post-fix + new tests: all 16 tests pass across both suites.

Also ran `cargo check`, `pnpm exec tsc --noEmit`, and `prettier --check .` (root, which is what CI's Prettier job actually runs — the subproject's own `pnpm lint` script pins an unrelated, older prettier version and isn't used by CI). No IDL/client regeneration needed — only `require!` conditions changed, not account structs or instruction signatures.

## Explicitly out of scope (flagged as follow-ups, not fixed here)

- **Lossy cast on a possibly-negative elapsed value:** `as u16` on a negative `i64` (clock set backwards) wraps to a large u16, which would flip both checks' effective behavior. A hardened version would widen to `i64` with `saturating_sub` instead of narrowing. Left out to keep this a minimal, obviously-correct diff.
- **`refund.rs`/`checker.rs` gate on `vault.amount` (the live ATA balance) instead of `fundraiser.current_amount` (the tracked value).** Since the vault is a plain ATA, anyone can transfer tokens into it directly to push `vault.amount >= amount_to_raise`, blocking refunds or enabling `check_contributions` without genuine contributions. Real, separate finding.
- **`check_contributions` closes the `Fundraiser` PDA while `Contributor` PDAs may still exist**, after which `refund` can never run for those contributors, stranding their rent. Also separate.