### PR TITLE
refactor(token-2022/default-account-state): use kit codecs for instruction data

### DIFF
--- a/tokens/token-2022/default-account-state/pinocchio/package.json
+++ b/tokens/token-2022/default-account-state/pinocchio/package.json
@@ -11,7 +11,6 @@
     "@solana-program/token-2022": "^0.12.0",
     "@solana/kit": "^7.0.0",
     "@solana/sysvars": "^6.10.0",
-    "borsh": "^2.0.0",
     "litesvm": "^1.3.0"
   },
   "devDependencies": {

--- a/tokens/token-2022/default-account-state/pinocchio/pnpm-lock.yaml
+++ b/tokens/token-2022/default-account-state/pinocchio/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@solana/sysvars':
         specifier: ^6.10.0
         version: 6.10.0(typescript@5.9.3)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
       litesvm:
         specifier: ^1.3.0
         version: 1.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1061,9 +1058,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
-
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
@@ -1229,24 +1223,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   litesvm-linux-arm64-musl@1.3.0:
     resolution: {integrity: sha512-FO9p6rx+/3h7R3CU7lkOebL+jy8UEDngSrENHu7pj9EOr78QVyE3Fm0O+WMnwXpMoCSgW0XLhu1cI9NHAbzCTA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   litesvm-linux-x64-gnu@1.3.0:
     resolution: {integrity: sha512-yXC8ZAdIei9JQ2xw5/BocOTu/7EqZuFPyhgENQ1mYDhjNpoyUbIuGCWnqtria14mDda0aV9yVev8plGUrUpjUw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   litesvm-linux-x64-musl@1.3.0:
     resolution: {integrity: sha512-oedromp1gTjShXmKmxZ1FYtnfM824vRcrPSPvGM0CrqJqKK61m1+tFwNRAVsDlpmWKvO/zsz90ctbgAUo/3TXg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   litesvm@1.3.0:
     resolution: {integrity: sha512-tMu9sBIqSbF1gQluXEUtGmXPfZlMc10tOoBVeDokgK77nl/CcuC506sEoFKM5Rq58Dkb070lBMVBLc43TbMUzQ==}
@@ -2545,8 +2543,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.4:
     dependencies:

--- a/tokens/token-2022/default-account-state/pinocchio/tests/test.ts
+++ b/tokens/token-2022/default-account-state/pinocchio/tests/test.ts
@@ -5,6 +5,8 @@ import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     generateKeyPairSigner,
+    getStructEncoder,
+    getU8Encoder,
     lamports,
     pipe,
     setTransactionMessageFeePayerSigner,
@@ -14,15 +16,11 @@ import {
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { AccountState, getMintDecoder, TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
-// Borsh schema for the instruction data, matching the program's
-// `CreateTokenArgs` (and the native example's wire format).
-const CreateTokenArgsSchema: borsh.Schema = {
-    struct: { token_decimals: 'u8' },
-};
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([['tokenDecimals', getU8Encoder()]]);
 
 // Token-2022 lays a mint with one extension out as:
 //   base account length (165) + account-type byte (1) + TLV entry (5) = 171
@@ -57,7 +55,7 @@ describe('Token-2022 Default Account State (Pinocchio)', () => {
 
         const mint = await generateKeyPairSigner();
 
-        const data = borsh.serialize(CreateTokenArgsSchema, { token_decimals: decimals });
+        const data = createTokenArgsEncoder.encode({ tokenDecimals: decimals });
 
         const ix = {
             programAddress: programId,


### PR DESCRIPTION
## What

The Pinocchio `default-account-state` test added in #652 serialized its instruction data with the `borsh` package. This repo's TS examples standardize on `@solana/kit` codecs, so swap it out and drop the extra dependency.

## Changes

- `tests/test.ts`: `borsh.serialize(CreateTokenArgsSchema, ...)` → `getStructEncoder([['tokenDecimals', getU8Encoder()]])`
- `package.json` / `pnpm-lock.yaml`: remove `borsh`

Mint account decoding was already using the official `@solana-program/token-2022` codecs and is unchanged.

## Test

`pnpm build-and-test` → 1 passing. `tsc --noEmit` clean.

## Note

`tokens/token-2022/non-transferable/pinocchio` (from #630) has the same borsh usage — left out of this PR, tracked separately.