### PR TITLE
refactor(tokens): use kit codecs for instruction data in Token-2022 and create-token examples

### DIFF
--- a/tokens/create-token/native/package.json
+++ b/tokens/create-token/native/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@solana-program/system": "^0.13.0",
     "@solana-program/token": "^0.15.0",
-    "@solana/kit": "^7.0.0",
-    "borsh": "^2.0.0"
+    "@solana/kit": "^7.0.0"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/tokens/create-token/native/pnpm-lock.yaml
+++ b/tokens/create-token/native/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@solana/kit':
         specifier: ^7.0.0
         version: 7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
     devDependencies:
       '@types/chai':
         specifier: ^5.2.3
@@ -1047,9 +1044,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@2.1.3:
     resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
@@ -2533,8 +2527,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.3:
     dependencies:

--- a/tokens/create-token/native/tests/test.ts
+++ b/tokens/create-token/native/tests/test.ts
@@ -1,6 +1,6 @@
-import { Buffer } from 'node:buffer';
 import {
     AccountRole,
+    addEncoderSizePrefix,
     address,
     type Address,
     appendTransactionMessageInstruction,
@@ -8,6 +8,10 @@ import {
     generateKeyPairSigner,
     getAddressEncoder,
     getProgramDerivedAddress,
+    getStructEncoder,
+    getU8Encoder,
+    getU32Encoder,
+    getUtf8Encoder,
     type KeyPairSigner,
     lamports,
     pipe,
@@ -17,25 +21,19 @@ import {
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { getMintDecoder, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
 const TOKEN_METADATA_PROGRAM_ID = address('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');
 const SYSVAR_RENT_ADDRESS = address('SysvarRent111111111111111111111111111111111');
 
-const CreateTokenArgsSchema: borsh.Schema = {
-    struct: {
-        token_title: 'string',
-        token_symbol: 'string',
-        token_uri: 'string',
-        token_decimals: 'u8',
-    },
-};
-
-function borshSerialize(schema: borsh.Schema, data: object): Buffer {
-    return Buffer.from(borsh.serialize(schema, data));
-}
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([
+    ['tokenTitle', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+    ['tokenSymbol', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+    ['tokenUri', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+    ['tokenDecimals', getU8Encoder()],
+]);
 
 const addressEncoder = getAddressEncoder();
 
@@ -70,11 +68,11 @@ describe('Create Tokens!', () => {
         const mintKeypair = await generateKeyPairSigner();
         const metadataAddress = await findMetadataPda(mintKeypair.address);
 
-        const instructionData = borshSerialize(CreateTokenArgsSchema, {
-            token_title: tokenTitle,
-            token_symbol: tokenSymbol,
-            token_uri: tokenUri,
-            token_decimals: tokenDecimals,
+        const instructionData = createTokenArgsEncoder.encode({
+            tokenTitle,
+            tokenSymbol,
+            tokenUri,
+            tokenDecimals,
         });
 
         const ix = {
@@ -89,7 +87,7 @@ describe('Create Tokens!', () => {
                 { address: TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY }, // Token program
                 { address: TOKEN_METADATA_PROGRAM_ID, role: AccountRole.READONLY }, // Token metadata program
             ],
-            data: new Uint8Array(instructionData),
+            data: instructionData,
         };
 
         const transactionMessage = pipe(

--- a/tokens/create-token/pinocchio/package.json
+++ b/tokens/create-token/pinocchio/package.json
@@ -11,7 +11,6 @@
     "@solana-program/system": "^0.12.2",
     "@solana-program/token": "^0.14.0",
     "@solana/kit": "^7.0.0",
-    "borsh": "^2.0.0",
     "litesvm": "^1.3.0"
   },
   "devDependencies": {

--- a/tokens/create-token/pinocchio/pnpm-lock.yaml
+++ b/tokens/create-token/pinocchio/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@solana/kit':
         specifier: ^7.0.0
         version: 7.0.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
       litesvm:
         specifier: ^1.3.0
         version: 1.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1033,9 +1030,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@2.1.3:
     resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
@@ -2509,8 +2503,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.3:
     dependencies:

--- a/tokens/create-token/pinocchio/tests/test.ts
+++ b/tokens/create-token/pinocchio/tests/test.ts
@@ -2,12 +2,17 @@ import { Buffer } from 'node:buffer';
 import * as path from 'node:path';
 import {
     AccountRole,
+    addEncoderSizePrefix,
     address,
     appendTransactionMessageInstruction,
     createTransactionMessage,
     generateKeyPairSigner,
     getAddressEncoder,
     getProgramDerivedAddress,
+    getStructEncoder,
+    getU8Encoder,
+    getU32Encoder,
+    getUtf8Encoder,
     lamports,
     pipe,
     setTransactionMessageFeePayerSigner,
@@ -15,7 +20,6 @@ import {
 } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
@@ -25,16 +29,13 @@ import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 // `@solana-program/*` client for Token Metadata, so its id stays hand-rolled.
 const TOKEN_METADATA_PROGRAM_ID = address('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');
 
-// Borsh schema for the instruction data, matching the program's `CreateTokenArgs`
-// (and the native example's wire format).
-const CreateTokenArgsSchema: borsh.Schema = {
-    struct: {
-        token_title: 'string',
-        token_symbol: 'string',
-        token_uri: 'string',
-        token_decimals: 'u8',
-    },
-};
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([
+    ['tokenTitle', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+    ['tokenSymbol', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+    ['tokenUri', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+    ['tokenDecimals', getU8Encoder()],
+]);
 
 // The compiled program artifacts live in ./fixtures: the pinocchio program is
 // built there by `build-and-test`, and token_metadata.so is dumped from mainnet
@@ -69,14 +70,12 @@ describe('Create Token (Pinocchio)', () => {
             seeds: ['metadata', addressEncoder.encode(TOKEN_METADATA_PROGRAM_ID), addressEncoder.encode(mint.address)],
         });
 
-        const data = Buffer.from(
-            borsh.serialize(CreateTokenArgsSchema, {
-                token_title: name,
-                token_symbol: symbol,
-                token_uri: uri,
-                token_decimals: decimals,
-            }),
-        );
+        const data = createTokenArgsEncoder.encode({
+            tokenTitle: name,
+            tokenSymbol: symbol,
+            tokenUri: uri,
+            tokenDecimals: decimals,
+        });
 
         const ix = {
             programAddress: programId,
@@ -89,7 +88,7 @@ describe('Create Token (Pinocchio)', () => {
                 { address: TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY }, // token program
                 { address: TOKEN_METADATA_PROGRAM_ID, role: AccountRole.READONLY }, // token metadata program
             ],
-            data: new Uint8Array(data),
+            data,
         };
 
         const transactionMessage = pipe(

--- a/tokens/token-2022/default-account-state/native/package.json
+++ b/tokens/token-2022/default-account-state/native/package.json
@@ -9,8 +9,7 @@
     "@solana-program/system": "^0.12.2",
     "@solana-program/token-2022": "^0.12.0",
     "@solana/kit": "^7.0.0",
-    "@solana/sysvars": "^6.10.0",
-    "borsh": "^2.0.0"
+    "@solana/sysvars": "^6.10.0"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/tokens/token-2022/default-account-state/native/pnpm-lock.yaml
+++ b/tokens/token-2022/default-account-state/native/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@solana/sysvars':
         specifier: ^6.10.0
         version: 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
     devDependencies:
       '@types/chai':
         specifier: ^5.2.3
@@ -1060,9 +1057,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@2.1.3:
     resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
@@ -2554,8 +2548,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.3:
     dependencies:

--- a/tokens/token-2022/default-account-state/native/tests/test.ts
+++ b/tokens/token-2022/default-account-state/native/tests/test.ts
@@ -5,6 +5,8 @@ import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     generateKeyPairSigner,
+    getStructEncoder,
+    getU8Encoder,
     type KeyPairSigner,
     lamports,
     pipe,
@@ -14,11 +16,11 @@ import {
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
-const CreateTokenArgsSchema: borsh.Schema = { struct: { token_decimals: 'u8' } };
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([['tokenDecimals', getU8Encoder()]]);
 
 const PROGRAM_SO = path.join(process.cwd(), 'tests', 'fixtures', 'token_2022_default_account_state_program.so');
 
@@ -39,7 +41,7 @@ describe('Create Token', () => {
     it('Create a Token-22 SPL-Token !', async () => {
         const mint = await generateKeyPairSigner();
 
-        const data = borsh.serialize(CreateTokenArgsSchema, { token_decimals: 9 });
+        const data = createTokenArgsEncoder.encode({ tokenDecimals: 9 });
 
         const ix = {
             programAddress: programId,

--- a/tokens/token-2022/mint-close-authority/native/package.json
+++ b/tokens/token-2022/mint-close-authority/native/package.json
@@ -9,8 +9,7 @@
     "@solana-program/system": "^0.12.2",
     "@solana-program/token-2022": "^0.12.0",
     "@solana/kit": "^7.0.0",
-    "@solana/sysvars": "^6.10.0",
-    "borsh": "^2.0.0"
+    "@solana/sysvars": "^6.10.0"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/tokens/token-2022/mint-close-authority/native/pnpm-lock.yaml
+++ b/tokens/token-2022/mint-close-authority/native/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@solana/sysvars':
         specifier: ^6.10.0
         version: 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
     devDependencies:
       '@types/chai':
         specifier: ^5.2.3
@@ -1060,9 +1057,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@2.1.3:
     resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
@@ -2554,8 +2548,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.3:
     dependencies:

--- a/tokens/token-2022/mint-close-authority/native/tests/test.ts
+++ b/tokens/token-2022/mint-close-authority/native/tests/test.ts
@@ -5,6 +5,8 @@ import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     generateKeyPairSigner,
+    getStructEncoder,
+    getU8Encoder,
     type KeyPairSigner,
     lamports,
     pipe,
@@ -14,11 +16,11 @@ import {
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
-const CreateTokenArgsSchema: borsh.Schema = { struct: { token_decimals: 'u8' } };
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([['tokenDecimals', getU8Encoder()]]);
 
 const PROGRAM_SO = path.join(process.cwd(), 'tests', 'fixtures', 'token_2022_mint_close_authority_program.so');
 
@@ -39,7 +41,7 @@ describe('Create Token', () => {
     it('Create a Token-22 SPL-Token !', async () => {
         const mint = await generateKeyPairSigner();
 
-        const data = borsh.serialize(CreateTokenArgsSchema, { token_decimals: 9 });
+        const data = createTokenArgsEncoder.encode({ tokenDecimals: 9 });
 
         const ix = {
             programAddress: programId,

--- a/tokens/token-2022/mint-close-authority/pinocchio/package.json
+++ b/tokens/token-2022/mint-close-authority/pinocchio/package.json
@@ -11,7 +11,6 @@
     "@solana-program/token-2022": "^0.12.0",
     "@solana/kit": "^7.0.0",
     "@solana/sysvars": "^6.10.0",
-    "borsh": "^2.0.0",
     "litesvm": "^1.3.0"
   },
   "devDependencies": {

--- a/tokens/token-2022/mint-close-authority/pinocchio/pnpm-lock.yaml
+++ b/tokens/token-2022/mint-close-authority/pinocchio/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@solana/sysvars':
         specifier: ^6.10.0
         version: 6.10.0(typescript@5.9.3)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
       litesvm:
         specifier: ^1.3.0
         version: 1.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1060,9 +1057,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@2.1.3:
     resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
@@ -2549,8 +2543,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.3:
     dependencies:

--- a/tokens/token-2022/mint-close-authority/pinocchio/tests/test.ts
+++ b/tokens/token-2022/mint-close-authority/pinocchio/tests/test.ts
@@ -5,6 +5,8 @@ import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     generateKeyPairSigner,
+    getStructEncoder,
+    getU8Encoder,
     lamports,
     pipe,
     setTransactionMessageFeePayerSigner,
@@ -14,15 +16,11 @@ import {
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { getMintDecoder, TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
-// Borsh schema for the instruction data, matching the program's
-// `CreateTokenArgs` (and the native example's wire format).
-const CreateTokenArgsSchema: borsh.Schema = {
-    struct: { token_decimals: 'u8' },
-};
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([['tokenDecimals', getU8Encoder()]]);
 
 // Token-2022 lays a mint with one extension out as:
 //   base account length (165) + account-type byte (1) + TLV entry (36) = 202
@@ -59,7 +57,7 @@ describe('Token-2022 Mint Close Authority (Pinocchio)', () => {
         // verifies it is sourced from account index 2, not the mint authority/payer.
         const closeAuthority = await generateKeyPairSigner();
 
-        const data = borsh.serialize(CreateTokenArgsSchema, { token_decimals: decimals });
+        const data = createTokenArgsEncoder.encode({ tokenDecimals: decimals });
 
         const ix = {
             programAddress: programId,

--- a/tokens/token-2022/multiple-extensions/native/package.json
+++ b/tokens/token-2022/multiple-extensions/native/package.json
@@ -9,8 +9,7 @@
     "@solana-program/system": "^0.12.2",
     "@solana-program/token-2022": "^0.12.0",
     "@solana/kit": "^7.0.0",
-    "@solana/sysvars": "^6.10.0",
-    "borsh": "^2.0.0"
+    "@solana/sysvars": "^6.10.0"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/tokens/token-2022/multiple-extensions/native/pnpm-lock.yaml
+++ b/tokens/token-2022/multiple-extensions/native/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@solana/sysvars':
         specifier: ^6.10.0
         version: 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
     devDependencies:
       '@types/chai':
         specifier: ^5.2.3
@@ -1060,9 +1057,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@2.1.3:
     resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
@@ -2554,8 +2548,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.3:
     dependencies:

--- a/tokens/token-2022/multiple-extensions/native/tests/test.ts
+++ b/tokens/token-2022/multiple-extensions/native/tests/test.ts
@@ -5,6 +5,8 @@ import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     generateKeyPairSigner,
+    getStructEncoder,
+    getU8Encoder,
     type KeyPairSigner,
     lamports,
     pipe,
@@ -14,11 +16,11 @@ import {
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
-const CreateTokenArgsSchema: borsh.Schema = { struct: { token_decimals: 'u8' } };
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([['tokenDecimals', getU8Encoder()]]);
 
 const PROGRAM_SO = path.join(process.cwd(), 'tests', 'fixtures', 'token_2022_multiple_extensions_program.so');
 
@@ -39,7 +41,7 @@ describe('Create Token', () => {
     it('Create a Token-22 SPL-Token !', async () => {
         const mint = await generateKeyPairSigner();
 
-        const data = borsh.serialize(CreateTokenArgsSchema, { token_decimals: 9 });
+        const data = createTokenArgsEncoder.encode({ tokenDecimals: 9 });
 
         const ix = {
             programAddress: programId,

--- a/tokens/token-2022/non-transferable/native/package.json
+++ b/tokens/token-2022/non-transferable/native/package.json
@@ -9,8 +9,7 @@
     "@solana-program/system": "^0.12.2",
     "@solana-program/token-2022": "^0.12.0",
     "@solana/kit": "^7.0.0",
-    "@solana/sysvars": "^6.10.0",
-    "borsh": "^2.0.0"
+    "@solana/sysvars": "^6.10.0"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/tokens/token-2022/non-transferable/native/pnpm-lock.yaml
+++ b/tokens/token-2022/non-transferable/native/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@solana/sysvars':
         specifier: ^6.10.0
         version: 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
     devDependencies:
       '@types/chai':
         specifier: ^5.2.3
@@ -1060,9 +1057,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@2.1.3:
     resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
@@ -2554,8 +2548,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.3:
     dependencies:

--- a/tokens/token-2022/non-transferable/native/tests/test.ts
+++ b/tokens/token-2022/non-transferable/native/tests/test.ts
@@ -5,6 +5,8 @@ import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     generateKeyPairSigner,
+    getStructEncoder,
+    getU8Encoder,
     type KeyPairSigner,
     lamports,
     pipe,
@@ -14,11 +16,11 @@ import {
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
-const CreateTokenArgsSchema: borsh.Schema = { struct: { token_decimals: 'u8' } };
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([['tokenDecimals', getU8Encoder()]]);
 
 const PROGRAM_SO = path.join(process.cwd(), 'tests', 'fixtures', 'token_2022_non_transferable_program.so');
 
@@ -39,7 +41,7 @@ describe('Create Token', () => {
     it('Create a Token-22 SPL-Token !', async () => {
         const mint = await generateKeyPairSigner();
 
-        const data = borsh.serialize(CreateTokenArgsSchema, { token_decimals: 9 });
+        const data = createTokenArgsEncoder.encode({ tokenDecimals: 9 });
 
         const ix = {
             programAddress: programId,

--- a/tokens/token-2022/non-transferable/pinocchio/package.json
+++ b/tokens/token-2022/non-transferable/pinocchio/package.json
@@ -11,7 +11,6 @@
     "@solana-program/token-2022": "^0.12.0",
     "@solana/kit": "^7.0.0",
     "@solana/sysvars": "^6.10.0",
-    "borsh": "^2.0.0",
     "litesvm": "^1.3.0"
   },
   "devDependencies": {

--- a/tokens/token-2022/non-transferable/pinocchio/pnpm-lock.yaml
+++ b/tokens/token-2022/non-transferable/pinocchio/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@solana/sysvars':
         specifier: ^6.10.0
         version: 6.10.0(typescript@5.9.3)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
       litesvm:
         specifier: ^1.3.0
         version: 1.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1060,9 +1057,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@2.1.3:
     resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
@@ -2549,8 +2543,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.3:
     dependencies:

--- a/tokens/token-2022/non-transferable/pinocchio/tests/test.ts
+++ b/tokens/token-2022/non-transferable/pinocchio/tests/test.ts
@@ -5,6 +5,8 @@ import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     generateKeyPairSigner,
+    getStructEncoder,
+    getU8Encoder,
     lamports,
     pipe,
     setTransactionMessageFeePayerSigner,
@@ -14,15 +16,11 @@ import {
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { getMintDecoder, TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
-// Borsh schema for the instruction data, matching the program's
-// `CreateTokenArgs` (and the native example's wire format).
-const CreateTokenArgsSchema: borsh.Schema = {
-    struct: { token_decimals: 'u8' },
-};
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([['tokenDecimals', getU8Encoder()]]);
 
 // Token-2022 lays a mint with one (valueless) extension out as:
 //   base account length (165) + account-type byte (1) + TLV entry (4) = 170
@@ -51,7 +49,7 @@ describe('Token-2022 Non-Transferable (Pinocchio)', () => {
 
         const mint = await generateKeyPairSigner();
 
-        const data = borsh.serialize(CreateTokenArgsSchema, { token_decimals: decimals });
+        const data = createTokenArgsEncoder.encode({ tokenDecimals: decimals });
 
         const ix = {
             programAddress: programId,

--- a/tokens/token-2022/transfer-fee/native/package.json
+++ b/tokens/token-2022/transfer-fee/native/package.json
@@ -9,8 +9,7 @@
     "@solana-program/system": "^0.12.2",
     "@solana-program/token-2022": "^0.12.0",
     "@solana/kit": "^7.0.0",
-    "@solana/sysvars": "^6.10.0",
-    "borsh": "^2.0.0"
+    "@solana/sysvars": "^6.10.0"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/tokens/token-2022/transfer-fee/native/pnpm-lock.yaml
+++ b/tokens/token-2022/transfer-fee/native/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@solana/sysvars':
         specifier: ^6.10.0
         version: 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
     devDependencies:
       '@types/chai':
         specifier: ^5.2.3
@@ -1060,9 +1057,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@2.1.3:
     resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
@@ -2554,8 +2548,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.3:
     dependencies:

--- a/tokens/token-2022/transfer-fee/native/tests/test.ts
+++ b/tokens/token-2022/transfer-fee/native/tests/test.ts
@@ -5,6 +5,8 @@ import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     generateKeyPairSigner,
+    getStructEncoder,
+    getU8Encoder,
     type KeyPairSigner,
     lamports,
     pipe,
@@ -14,11 +16,11 @@ import {
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
-const CreateTokenArgsSchema: borsh.Schema = { struct: { token_decimals: 'u8' } };
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([['tokenDecimals', getU8Encoder()]]);
 
 const PROGRAM_SO = path.join(process.cwd(), 'tests', 'fixtures', 'token_2022_transfer_fees_program.so');
 
@@ -39,7 +41,7 @@ describe('Create Token', () => {
     it('Create a Token-22 SPL-Token !', async () => {
         const mint = await generateKeyPairSigner();
 
-        const data = borsh.serialize(CreateTokenArgsSchema, { token_decimals: 9 });
+        const data = createTokenArgsEncoder.encode({ tokenDecimals: 9 });
 
         const ix = {
             programAddress: programId,


### PR DESCRIPTION
## What changed

Instruction data in these example test suites was built with the `borsh` package. This swaps that for `@solana/kit` codecs (`getStructEncoder` + `getU8Encoder`, plus `addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())` for the string fields in the create-token examples), so the examples rely on a single serialization library instead of two.

- `borsh` removed from `dependencies` in all nine packages (no borsh usage remains in any of them)
- Lockfiles regenerated with the repo-pinned `pnpm@10.33.0`
- Wire format is unchanged: kit's u32-length-prefixed UTF-8 string matches borsh's `string`

Follows the pattern established in #675.

## Packages

- `tokens/token-2022/default-account-state/native`
- `tokens/token-2022/mint-close-authority/native`
- `tokens/token-2022/mint-close-authority/pinocchio`
- `tokens/token-2022/non-transferable/native`
- `tokens/token-2022/non-transferable/pinocchio`
- `tokens/token-2022/transfer-fee/native`
- `tokens/token-2022/multiple-extensions/native`
- `tokens/create-token/native`
- `tokens/create-token/pinocchio`

## Test evidence

For each package: `pnpm install`, `tsc --noEmit`, and `pnpm build-and-test` (cargo build-sbf + mocha/LiteSVM). All nine pass.

```
PASS tokens/token-2022/default-account-state/native
PASS tokens/token-2022/mint-close-authority/native
PASS tokens/token-2022/mint-close-authority/pinocchio
PASS tokens/token-2022/non-transferable/native
PASS tokens/token-2022/non-transferable/pinocchio
PASS tokens/token-2022/transfer-fee/native
PASS tokens/token-2022/multiple-extensions/native
PASS tokens/create-token/native
PASS tokens/create-token/pinocchio
```

`prettier --check` is clean on every changed file.

Part of DEV-838
