### PR TITLE
refactor(token-2022/transfer-fee): encode instruction data with kit codecs

### DIFF
--- a/tokens/token-2022/transfer-fee/pinocchio/package.json
+++ b/tokens/token-2022/transfer-fee/pinocchio/package.json
@@ -11,7 +11,6 @@
     "@solana-program/token-2022": "^0.12.0",
     "@solana/kit": "^7.0.0",
     "@solana/sysvars": "^6.10.0",
-    "borsh": "^2.0.0",
     "litesvm": "^1.3.0"
   },
   "devDependencies": {

--- a/tokens/token-2022/transfer-fee/pinocchio/pnpm-lock.yaml
+++ b/tokens/token-2022/transfer-fee/pinocchio/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@solana/sysvars':
         specifier: ^6.10.0
         version: 6.10.0(typescript@5.9.3)
-      borsh:
-        specifier: ^2.0.0
-        version: 2.0.0
       litesvm:
         specifier: ^1.3.0
         version: 1.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -1060,9 +1057,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  borsh@2.0.0:
-    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
@@ -2545,8 +2539,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
-
-  borsh@2.0.0: {}
 
   brace-expansion@2.1.4:
     dependencies:

--- a/tokens/token-2022/transfer-fee/pinocchio/tests/test.ts
+++ b/tokens/token-2022/transfer-fee/pinocchio/tests/test.ts
@@ -5,6 +5,8 @@ import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     generateKeyPairSigner,
+    getStructEncoder,
+    getU8Encoder,
     lamports,
     pipe,
     setTransactionMessageFeePayerSigner,
@@ -14,15 +16,11 @@ import {
 import { SYSVAR_RENT_ADDRESS } from '@solana/sysvars';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { getMintDecoder, TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
-import * as borsh from 'borsh';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
-// Borsh schema for the instruction data, matching the program's
-// `CreateTokenArgs` (and the native example's wire format).
-const CreateTokenArgsSchema: borsh.Schema = {
-    struct: { token_decimals: 'u8' },
-};
+// Instruction data layout, matching the program's `CreateTokenArgs`.
+const createTokenArgsEncoder = getStructEncoder([['tokenDecimals', getU8Encoder()]]);
 
 // Token-2022 lays a mint with one extension out as:
 //   base account length (165) + account-type byte (1) + TLV entry (112) = 278
@@ -54,7 +52,7 @@ describe('Token-2022 Transfer Fee (Pinocchio)', () => {
 
         const mint = await generateKeyPairSigner();
 
-        const data = borsh.serialize(CreateTokenArgsSchema, { token_decimals: decimals });
+        const data = createTokenArgsEncoder.encode({ tokenDecimals: decimals });
 
         const ix = {
             programAddress: programId,


### PR DESCRIPTION
Follow-up consistency cleanup on the merged `token-2022/transfer-fee/pinocchio` example.

Builds the `CreateToken` instruction data with `@solana/kit` codecs (`getStructEncoder` + `getU8Encoder`) instead of the `borsh` npm package, and drops the `borsh` dependency. This matches the pattern applied in `default-account-state` (#675, @amilz) and `pda-mint-authority`, keeping the pinocchio token-2022 examples consistent.

No on-chain change — the litesvm test passes unchanged (verified on the Linux/SBF path).