### PR TITLE
Fix 'seperate' typo in test comments

### DIFF
--- a/tokens/escrow/anchor/tests/litesvm.test.ts
+++ b/tokens/escrow/anchor/tests/litesvm.test.ts
@@ -134,7 +134,7 @@ describe('Escrow LiteSVM example', () => {
     const tokenAOfferedAmount = new BN(1_000_000);
     const tokenBWantedAmount = new BN(1_000_000);
 
-    // We'll call this function from multiple tests, so let's seperate it out
+    // We'll call this function from multiple tests, so let's separate it out
     const make = async () => {
         // Pick a random ID for the offer we'll make
         const offerId = getRandomBigNumber();
@@ -170,7 +170,7 @@ describe('Escrow LiteSVM example', () => {
         assert(offerAccount.tokenBWantedAmount.eq(tokenBWantedAmount));
     };
 
-    // We'll call this function from multiple tests, so let's seperate it out
+    // We'll call this function from multiple tests, so let's separate it out
     const take = async () => {
         const _transactionSignature = await program.methods
             .takeOffer()


### PR DESCRIPTION
Minor typo in code comments: `seperate` should be `separate` (two occurrences in `tokens/escrow/anchor/tests/litesvm.test.ts`). No code change.
