### PR TITLE
refactor(basics/close-account): replace borsh with kit codecs in native example

### DIFF
--- a/basics/close-account/native/package.json
+++ b/basics/close-account/native/package.json
@@ -8,8 +8,7 @@
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",
-    "@solana-program/system": "^0.13.0",
-    "borsh": "^0.7.0"
+    "@solana-program/system": "^0.13.0"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/basics/close-account/native/pnpm-lock.yaml
+++ b/basics/close-account/native/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@solana/kit':
         specifier: ^7.0.0
         version: 7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      borsh:
-        specifier: ^0.7.0
-        version: 0.7.0
     devDependencies:
       '@types/chai':
         specifier: ^5.2.3
@@ -1036,23 +1033,11 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  base-x@3.0.11:
-    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
-
-  bn.js@5.2.2:
-    resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
-
-  borsh@0.7.0:
-    resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
-
   brace-expansion@2.1.3:
     resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
 
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
-
-  bs58@4.0.1:
-    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
 
   bufferutil@4.0.9:
     resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
@@ -1356,9 +1341,6 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
-
-  text-encoding-utf-8@1.0.2:
-    resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
 
   tsx@4.23.1:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
@@ -2524,27 +2506,11 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base-x@3.0.11:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  bn.js@5.2.2: {}
-
-  borsh@0.7.0:
-    dependencies:
-      bn.js: 5.2.2
-      bs58: 4.0.1
-      text-encoding-utf-8: 1.0.2
-
   brace-expansion@2.1.3:
     dependencies:
       balanced-match: 1.0.2
 
   browser-stdout@1.3.1: {}
-
-  bs58@4.0.1:
-    dependencies:
-      base-x: 3.0.11
 
   bufferutil@4.0.9:
     dependencies:
@@ -2842,8 +2808,6 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
-
-  text-encoding-utf-8@1.0.2: {}
 
   tsx@4.23.1:
     dependencies:

--- a/basics/close-account/native/tests/close-account.test.ts
+++ b/basics/close-account/native/tests/close-account.test.ts
@@ -11,12 +11,14 @@ import {
     setTransactionMessageFeePayerSigner,
     signTransactionMessageWithSigners,
 } from '@solana/kit';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
 import { assert } from 'chai';
 import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
-import { createCloseUserInstruction, createCreateUserInstruction } from '../ts';
+import { createCloseUserInstruction, createCreateUserInstruction, userDecoder } from '../ts';
 
 describe('Close Account!', () => {
     const svm = new LiteSVM();
+    const userName = 'Jacob';
     let programId: Address;
     let payer: KeyPairSigner;
     let testAccountAddress: Address;
@@ -34,7 +36,7 @@ describe('Close Account!', () => {
     });
 
     it('Create the account', async () => {
-        const ix = createCreateUserInstruction(testAccountAddress, payer, programId, 'Jacob');
+        const ix = createCreateUserInstruction(testAccountAddress, payer, programId, userName);
 
         const transactionMessage = pipe(
             createTransactionMessage({ version: 0 }),
@@ -46,6 +48,11 @@ describe('Close Account!', () => {
 
         const result = svm.sendTransaction(signedTx);
         assert(!(result instanceof FailedTransactionMetadata), `transaction failed: ${result.toString()}`);
+
+        const account = svm.getAccount(testAccountAddress);
+        assert(account.exists);
+        assert.equal(account.programAddress, programId);
+        assert.equal(userDecoder.decode(account.data).name, userName);
     });
 
     it("An attacker cannot close another user's account", async () => {
@@ -88,5 +95,12 @@ describe('Close Account!', () => {
 
         const result = svm.sendTransaction(signedTx);
         assert(!(result instanceof FailedTransactionMetadata), `transaction failed: ${result.toString()}`);
+
+        // Closing resizes the account to zero and hands ownership back to the
+        // System Program, leaving only the rent-exempt minimum for a 0-byte account.
+        const account = svm.getAccount(testAccountAddress);
+        assert(account.exists);
+        assert.equal(account.programAddress, SYSTEM_PROGRAM_ADDRESS);
+        assert.equal(account.data.length, 0);
     });
 });

--- a/basics/close-account/native/ts/instructions/close.ts
+++ b/basics/close-account/native/ts/instructions/close.ts
@@ -1,40 +1,11 @@
-import { Buffer } from 'node:buffer';
-import { AccountRole, type Address, type TransactionSigner } from '@solana/kit';
+import { AccountRole, type Address, getStructEncoder, getU8Encoder, type TransactionSigner } from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
-import * as borsh from 'borsh';
 import { MyInstruction } from '.';
 
-export class Close {
-    instruction: MyInstruction;
-
-    constructor(props: { instruction: MyInstruction }) {
-        this.instruction = props.instruction;
-    }
-
-    toBuffer() {
-        return Buffer.from(borsh.serialize(CloseSchema, this));
-    }
-
-    static fromBuffer(buffer: Buffer) {
-        return borsh.deserialize(CloseSchema, Close, buffer);
-    }
-}
-
-export const CloseSchema = new Map([
-    [
-        Close,
-        {
-            kind: 'struct',
-            fields: [['instruction', 'u8']],
-        },
-    ],
-]);
+// Instruction data layout, matching the program's `MyInstruction::CloseUser` variant.
+export const closeUserEncoder = getStructEncoder([['instruction', getU8Encoder()]]);
 
 export function createCloseUserInstruction(target: Address, payer: TransactionSigner, programId: Address) {
-    const instructionObject = new Close({
-        instruction: MyInstruction.CloseUser,
-    });
-
     return {
         programAddress: programId,
         accounts: [
@@ -42,6 +13,6 @@ export function createCloseUserInstruction(target: Address, payer: TransactionSi
             { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
             { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
         ],
-        data: new Uint8Array(instructionObject.toBuffer()),
+        data: closeUserEncoder.encode({ instruction: MyInstruction.CloseUser }),
     };
 }

--- a/basics/close-account/native/ts/instructions/create.ts
+++ b/basics/close-account/native/ts/instructions/create.ts
@@ -1,38 +1,20 @@
-import { Buffer } from 'node:buffer';
-import { AccountRole, type Address, type TransactionSigner } from '@solana/kit';
+import {
+    AccountRole,
+    addEncoderSizePrefix,
+    type Address,
+    getStructEncoder,
+    getU8Encoder,
+    getU32Encoder,
+    getUtf8Encoder,
+    type TransactionSigner,
+} from '@solana/kit';
 import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
-import * as borsh from 'borsh';
 import { MyInstruction } from '.';
 
-export class Create {
-    instruction: MyInstruction;
-    name: string;
-
-    constructor(props: { instruction: MyInstruction; name: string }) {
-        this.instruction = props.instruction;
-        this.name = props.name;
-    }
-
-    toBuffer() {
-        return Buffer.from(borsh.serialize(CreateSchema, this));
-    }
-
-    static fromBuffer(buffer: Buffer) {
-        return borsh.deserialize(CreateSchema, Create, buffer);
-    }
-}
-
-export const CreateSchema = new Map([
-    [
-        Create,
-        {
-            kind: 'struct',
-            fields: [
-                ['instruction', 'u8'],
-                ['name', 'string'],
-            ],
-        },
-    ],
+// Instruction data layout, matching the program's `MyInstruction::CreateUser(User)` variant.
+export const createUserEncoder = getStructEncoder([
+    ['instruction', getU8Encoder()],
+    ['name', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
 ]);
 
 export function createCreateUserInstruction(
@@ -41,11 +23,6 @@ export function createCreateUserInstruction(
     programId: Address,
     name: string,
 ) {
-    const instructionObject = new Create({
-        instruction: MyInstruction.CreateUser,
-        name,
-    });
-
     return {
         programAddress: programId,
         accounts: [
@@ -53,6 +30,6 @@ export function createCreateUserInstruction(
             { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
             { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
         ],
-        data: new Uint8Array(instructionObject.toBuffer()),
+        data: createUserEncoder.encode({ instruction: MyInstruction.CreateUser, name }),
     };
 }

--- a/basics/close-account/native/ts/state/index.ts
+++ b/basics/close-account/native/ts/state/index.ts
@@ -1,32 +1,4 @@
-import { Buffer } from 'node:buffer';
-import * as borsh from 'borsh';
+import { addDecoderSizePrefix, getStructDecoder, getU32Decoder, getUtf8Decoder } from '@solana/kit';
 
-export class User {
-    name: string;
-
-    constructor(props: { name: string }) {
-        this.name = props.name;
-    }
-
-    toBase58() {
-        return borsh.serialize(UserSchema, this).toString();
-    }
-
-    toBuffer() {
-        return Buffer.from(borsh.serialize(UserSchema, this));
-    }
-
-    static fromBuffer(buffer: Buffer) {
-        return borsh.deserialize(UserSchema, User, buffer);
-    }
-}
-
-export const UserSchema = new Map([
-    [
-        User,
-        {
-            kind: 'struct',
-            fields: [['name', 'string']],
-        },
-    ],
-]);
+// Account data layout, matching the program's `User` struct.
+export const userDecoder = getStructDecoder([['name', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())]]);


### PR DESCRIPTION
## Summary
- `basics/close-account/native` was the last package pinned to `borsh: ^0.7.0` — the only pre-2.x pin in the repo — and called `deserialize(schema, Class, buffer)`, a signature that no longer exists in borsh 2.x. Dropped the dep and regenerated the lockfile.
- Instruction data now uses `getStructEncoder`, with `addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())` for the `name` string, matching the pattern from #676.
- `ts/state/index.ts` exposes a `userDecoder` for the on-chain `User` layout in place of the borsh class boilerplate.
- Test asserts real post-state: the decoded account `name` after create, and the System Program owner plus zero-length data after close.

## Test Plan
- `pnpm build-and-test` in `basics/close-account/native` — 3 passing
- `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- `pnpm run check` (prettier) — clean
- Broke each new assertion once to confirm it fails loudly

Closes DEV-838