### PR TITLE
security: fix swapped transfer amounts + broken invariant check in token-swap

### DIFF
--- a/tokens/token-swap/anchor/programs/token-swap/src/errors.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/errors.rs
@@ -16,4 +16,7 @@ pub enum TutorialError {
 
     #[msg("Invariant does not hold")]
     InvariantViolated,
+
+    #[msg("Math overflowed")]
+    MathOverflow,
 }

--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
@@ -26,10 +26,10 @@ pub fn swap_exact_tokens_for_tokens(
     };
 
     // Apply trading fee, used to compute the output.
-    // u128 avoids overflow when input * fee approaches u64::MAX.
+    // u128 + checked math avoids overflow when input * fee approaches u64::MAX.
     let amm = &ctx.accounts.amm;
-    let fee_amount = ((input as u128) * (amm.fee as u128) / 10000) as u64;
-    let taxed_input = input - fee_amount;
+    let fee_amount = (input as u128).checked_mul(amm.fee as u128).unwrap().checked_div(10000).unwrap() as u64;
+    let taxed_input = input.checked_sub(fee_amount).unwrap();
 
     let pool_a = &ctx.accounts.pool_account_a;
     let pool_b = &ctx.accounts.pool_account_b;

--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
@@ -25,9 +25,11 @@ pub fn swap_exact_tokens_for_tokens(
         input_amount
     };
 
-    // Apply trading fee, used to compute the output
+    // Apply trading fee, used to compute the output.
+    // u128 avoids overflow when input * fee approaches u64::MAX.
     let amm = &ctx.accounts.amm;
-    let taxed_input = input - input * amm.fee as u64 / 10000;
+    let fee_amount = ((input as u128) * (amm.fee as u128) / 10000) as u64;
+    let taxed_input = input - fee_amount;
 
     let pool_a = &ctx.accounts.pool_account_a;
     let pool_b = &ctx.accounts.pool_account_b;
@@ -51,8 +53,8 @@ pub fn swap_exact_tokens_for_tokens(
         return err!(TutorialError::OutputTooSmall);
     }
 
-    // Compute the invariant before the trade
-    let invariant = pool_a.amount * pool_b.amount;
+    // Compute the invariant before the trade (u128 to avoid overflow on large pools)
+    let invariant = (pool_a.amount as u128) * (pool_b.amount as u128);
 
     // Transfer tokens to the pool
     let authority_bump = ctx.bumps.pool_authority;
@@ -99,7 +101,7 @@ pub fn swap_exact_tokens_for_tokens(
                 },
                 signer_seeds,
             ),
-            input,
+            output,
         )?;
         token::transfer(
             CpiContext::new(
@@ -110,7 +112,7 @@ pub fn swap_exact_tokens_for_tokens(
                     authority: ctx.accounts.trader.to_account_info(),
                 },
             ),
-            output,
+            input,
         )?;
     }
 
@@ -126,7 +128,8 @@ pub fn swap_exact_tokens_for_tokens(
     // We tolerate if the new invariant is higher because it means a rounding error for LPs
     ctx.accounts.pool_account_a.reload()?;
     ctx.accounts.pool_account_b.reload()?;
-    if invariant > ctx.accounts.pool_account_a.amount * ctx.accounts.pool_account_a.amount {
+    let new_invariant = (ctx.accounts.pool_account_a.amount as u128) * (ctx.accounts.pool_account_b.amount as u128);
+    if invariant > new_invariant {
         return err!(TutorialError::InvariantViolated);
     }
 

--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
@@ -28,8 +28,12 @@ pub fn swap_exact_tokens_for_tokens(
     // Apply trading fee, used to compute the output.
     // u128 + checked math avoids overflow when input * fee approaches u64::MAX.
     let amm = &ctx.accounts.amm;
-    let fee_amount = (input as u128).checked_mul(amm.fee as u128).unwrap().checked_div(10000).unwrap() as u64;
-    let taxed_input = input.checked_sub(fee_amount).unwrap();
+    let fee_amount = (input as u128)
+        .checked_mul(amm.fee as u128)
+        .ok_or(TutorialError::MathOverflow)?
+        .checked_div(10000)
+        .ok_or(TutorialError::MathOverflow)? as u64;
+    let taxed_input = input.checked_sub(fee_amount).ok_or(TutorialError::MathOverflow)?;
 
     let pool_a = &ctx.accounts.pool_account_a;
     let pool_b = &ctx.accounts.pool_account_b;
@@ -38,15 +42,15 @@ pub fn swap_exact_tokens_for_tokens(
     let output = if swap_a {
         (taxed_input as u128)
             .checked_mul(pool_b.amount as u128)
-            .unwrap()
-            .checked_div((pool_a.amount as u128).checked_add(taxed_input as u128).unwrap())
-            .unwrap()
+            .ok_or(TutorialError::MathOverflow)?
+            .checked_div((pool_a.amount as u128).checked_add(taxed_input as u128).ok_or(TutorialError::MathOverflow)?)
+            .ok_or(TutorialError::MathOverflow)?
     } else {
         (taxed_input as u128)
             .checked_mul(pool_a.amount as u128)
-            .unwrap()
-            .checked_div((pool_b.amount as u128).checked_add(taxed_input as u128).unwrap())
-            .unwrap()
+            .ok_or(TutorialError::MathOverflow)?
+            .checked_div((pool_b.amount as u128).checked_add(taxed_input as u128).ok_or(TutorialError::MathOverflow)?)
+            .ok_or(TutorialError::MathOverflow)?
     } as u64;
 
     if output < min_output_amount {

--- a/tokens/token-swap/anchor/tests/swap.ts
+++ b/tokens/token-swap/anchor/tests/swap.ts
@@ -95,6 +95,13 @@ describe('Swap', () => {
 
     it('Swap from B to A', async () => {
         const input = new anchor.BN(3 * 10 ** 6);
+
+        // Mirror the on-chain constant-product formula exactly, so this
+        // asserts the precise output amount rather than a broad range.
+        const feeAmount = input.mul(new anchor.BN(values.fee)).div(new anchor.BN(10000));
+        const taxedInput = input.sub(feeAmount);
+        const expectedOutput = taxedInput.mul(values.depositAmountA).div(values.depositAmountB.add(taxedInput));
+
         await program.methods
             .swapExactTokensForTokens(false, input, new anchor.BN(100))
             .accountsPartial({
@@ -117,11 +124,8 @@ describe('Swap', () => {
         expect(traderTokenAccountB.value.amount).to.equal(
             values.defaultSupply.sub(values.depositAmountB).sub(input).toString(),
         );
-        expect(Number(traderTokenAccountA.value.amount)).to.be.greaterThan(
-            values.defaultSupply.sub(values.depositAmountA).toNumber(),
-        );
-        expect(Number(traderTokenAccountA.value.amount)).to.be.lessThan(
-            values.defaultSupply.sub(values.depositAmountA).add(input).toNumber(),
+        expect(traderTokenAccountA.value.amount).to.equal(
+            values.defaultSupply.sub(values.depositAmountA).add(expectedOutput).toString(),
         );
     });
 });

--- a/tokens/token-swap/anchor/tests/swap.ts
+++ b/tokens/token-swap/anchor/tests/swap.ts
@@ -92,4 +92,36 @@ describe('Swap', () => {
             values.defaultSupply.sub(values.depositAmountB).add(input).toNumber(),
         );
     });
+
+    it('Swap from B to A', async () => {
+        const input = new anchor.BN(3 * 10 ** 6);
+        await program.methods
+            .swapExactTokensForTokens(false, input, new anchor.BN(100))
+            .accountsPartial({
+                amm: values.ammKey,
+                pool: values.poolKey,
+                poolAuthority: values.poolAuthority,
+                trader: values.admin.publicKey,
+                mintA: values.mintAKeypair.publicKey,
+                mintB: values.mintBKeypair.publicKey,
+                poolAccountA: values.poolAccountA,
+                poolAccountB: values.poolAccountB,
+                traderAccountA: values.holderAccountA,
+                traderAccountB: values.holderAccountB,
+            })
+            .signers([values.admin])
+            .rpc({ skipPreflight: true });
+
+        const traderTokenAccountA = await connection.getTokenAccountBalance(values.holderAccountA);
+        const traderTokenAccountB = await connection.getTokenAccountBalance(values.holderAccountB);
+        expect(traderTokenAccountB.value.amount).to.equal(
+            values.defaultSupply.sub(values.depositAmountB).sub(input).toString(),
+        );
+        expect(Number(traderTokenAccountA.value.amount)).to.be.greaterThan(
+            values.defaultSupply.sub(values.depositAmountA).toNumber(),
+        );
+        expect(Number(traderTokenAccountA.value.amount)).to.be.lessThan(
+            values.defaultSupply.sub(values.depositAmountA).add(input).toNumber(),
+        );
+    });
 });


### PR DESCRIPTION
## Summary

`swap_exact_tokens_for_tokens`'s `swap_a == false` branch (B→A swaps) has two independent bugs in the same ~20-line block. Neither was ever exercised by the existing tests — the only swap test always calls `swap_a = true`.

### Bug 1 (the severe one): transfer amounts are swapped in the B→A branch

```rust
} else {
    token::transfer(/* pool_account_a -> trader_account_a */ .., input)?;   // should be `output`
    token::transfer(/* trader_account_b -> pool_account_b */ .., output)?;  // should be `input`
}
```
Compare to the correct `swap_a == true` branch just above it, which moves `input` trader→pool and `output` pool→trader. In the `else` branch the two amounts are swapped: the pool pays out `input` (the raw, caller-chosen B amount, reused as if it were the A payout) instead of the formula-computed `output`, and the trader only pays `output` instead of the full `input` they claimed to be swapping.

**Hand-verified this drains real value**: on a pool with `pool_a=1,000,000` / `pool_b=4,000,000` (5% fee), `input=500,000` lets a trader pull out half the pool's entire A reserve while only paying ~106,145 B — the invariant drops from `4e12` to `~2.05e12` in one call.

### Bug 2: the post-trade invariant check compares the wrong accounts

```rust
if invariant > ctx.accounts.pool_account_a.amount * ctx.accounts.pool_account_a.amount {
    return err!(TutorialError::InvariantViolated);
}
```
`pool_account_a.amount` is multiplied by **itself** instead of by `pool_account_b.amount` — comparing pre-trade `A0*B0` against post-trade `A1*A1`, not `A1*B1`. This check is meant to be the AMM's final safety net (per its own comment) but as written never actually verifies the real constant-product invariant.

### Why both had to be fixed together

These two bugs currently mask each other by coincidence: severe drains via Bug 1 always shrink `pool_account_a` a lot, and shrinking `A` a lot also shrinks `A²` a lot — so Bug 2's check, wrong as it is, still happens to reject the most extreme drain attempts. A more moderate trade can still be profitably exploitable while slipping under that coincidental threshold. Fixing either bug alone — without the other — would remove the accidental protection and make the remaining bug fully exploitable. Both are fixed in this PR.

### Secondary fix: overflow-safe arithmetic

Also switched the pre/post-trade invariant computation and the fee calculation to `u128` arithmetic, matching the checked-math style already used for the output-amount calculation in the same function. The raw `u64` multiplications could otherwise overflow and panic (`overflow-checks = true` in this workspace's release profile) for large-supply pools.

## Test changes

Added `'Swap from B to A'` to `tests/swap.ts` — the first test in this example to exercise that branch at all. Verified it fails against the unpatched code (reverts with `InvariantViolated`, since the trade genuinely destroys value under the old code) and passes after the fix, with all other existing tests unaffected.

## Verification

- `cargo check` clean.
- `anchor build` — no account-struct or instruction-signature changes, IDL unaffected beyond recompilation.
- Full `anchor test` suite (`create-amm.ts`, `create-pool.ts`, `deposit-liquidity.ts`, `withdraw-liquidity.ts`, `swap.ts`) — all 10 tests pass post-fix.
- Ran the pre-fix/post-fix matrix: captured the fix as a patch, reverted only the program file, rebuilt, confirmed the new test fails (and only that test — nothing else regresses), reapplied the patch, confirmed all 10 pass.
- `pnpm exec tsc --noEmit` and `prettier --check` clean on the modified test file.

## Explicitly out of scope

- `create_amm.rs`'s `admin` field is never actually used to gate any instruction (dead authority field) — a minor design smell, not exploitable since nothing checks it, not touched here.
- Pool creation is fully permissionless (anyone can create a pool for any AMM+mint pair) — standard, intentional AMM-factory design, not a bug.
- `deposit_liquidity.rs`'s `MINIMUM_LIQUIDITY` handling (withheld from the first LP mint rather than minted-then-burned) — investigated and confirmed self-consistent with `withdraw_liquidity.rs`'s redemption formula, which compensates for it in the supply denominator. Not a bug.