### PR TITLE
security: gate pda-mint-authority's mint_token behind the token's original creator

### DIFF
--- a/tokens/pda-mint-authority/anchor/programs/token-minter/src/errors.rs
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/src/errors.rs
@@ -1,0 +1,7 @@
+use anchor_lang::prelude::*;
+
+#[error_code]
+pub enum TokenMinterError {
+    #[msg("Only the admin recorded at token creation may mint")]
+    Unauthorized,
+}

--- a/tokens/pda-mint-authority/anchor/programs/token-minter/src/instructions/create.rs
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/src/instructions/create.rs
@@ -1,11 +1,11 @@
 // In this example the same PDA is used as both the address of the mint account and the mint authority
 // This is to demonstrate that the same PDA can be used for both the address of an account and CPI signing
 use {
+    crate::state::MintConfig,
     anchor_lang::prelude::*,
     anchor_spl::{
         metadata::{
-            create_metadata_accounts_v3, mpl_token_metadata::types::DataV2,
-            CreateMetadataAccountsV3, Metadata,
+            create_metadata_accounts_v3, mpl_token_metadata::types::DataV2, CreateMetadataAccountsV3, Metadata,
         },
         token::{Mint, Token},
     },
@@ -38,6 +38,17 @@ pub struct CreateToken<'info> {
         seeds::program = token_metadata_program.key(),
     )]
     pub metadata_account: UncheckedAccount<'info>,
+
+    // Records who is allowed to mint, since the mint authority PDA itself signs
+    // unconditionally for whoever calls the mint instruction.
+    #[account(
+        init,
+        payer = payer,
+        space = MintConfig::LEN,
+        seeds = [b"mint_config"],
+        bump,
+    )]
+    pub mint_config: Account<'info, MintConfig>,
 
     pub token_program: Program<'info, Token>,
     pub token_metadata_program: Program<'info, Metadata>,
@@ -85,6 +96,8 @@ pub fn create_token(
         true,  // Update authority is signer
         None,  // Collection details
     )?;
+
+    ctx.accounts.mint_config.admin = ctx.accounts.payer.key();
 
     msg!("Token created successfully.");
 

--- a/tokens/pda-mint-authority/anchor/programs/token-minter/src/instructions/mint.rs
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/src/instructions/mint.rs
@@ -1,4 +1,5 @@
 use {
+    crate::{errors::TokenMinterError, state::MintConfig},
     anchor_lang::prelude::*,
     anchor_spl::{
         associated_token::AssociatedToken,
@@ -19,6 +20,14 @@ pub struct MintToken<'info> {
     )]
     pub mint_account: Account<'info, Mint>,
 
+    // Only the wallet recorded as admin at create_token time may mint.
+    #[account(
+        seeds = [b"mint_config"],
+        bump,
+        constraint = mint_config.admin == payer.key() @ TokenMinterError::Unauthorized,
+    )]
+    pub mint_config: Account<'info, MintConfig>,
+
     // Create Associated Token Account, if needed
     // This is the account that will hold the minted tokens
     #[account(
@@ -37,10 +46,7 @@ pub struct MintToken<'info> {
 pub fn mint_token(ctx: Context<MintToken>, amount: u64) -> Result<()> {
     msg!("Minting token to associated token account...");
     msg!("Mint: {}", &ctx.accounts.mint_account.key());
-    msg!(
-        "Token Address: {}",
-        &ctx.accounts.associated_token_account.key()
-    );
+    msg!("Token Address: {}", &ctx.accounts.associated_token_account.key());
 
     // PDA signer seeds
     let signer_seeds: &[&[&[u8]]] = &[&[b"mint", &[ctx.bumps.mint_account]]];

--- a/tokens/pda-mint-authority/anchor/programs/token-minter/src/lib.rs
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/src/lib.rs
@@ -1,6 +1,8 @@
 use anchor_lang::prelude::*;
 use instructions::*;
+pub mod errors;
 pub mod instructions;
+pub mod state;
 
 declare_id!("3LFrPHqwk5jMrmiz48BFj6NV2k4NjobgTe1jChzx3JGD");
 

--- a/tokens/pda-mint-authority/anchor/programs/token-minter/src/state.rs
+++ b/tokens/pda-mint-authority/anchor/programs/token-minter/src/state.rs
@@ -1,0 +1,13 @@
+use anchor_lang::prelude::*;
+
+// Tracks who is allowed to mint from this program's single global mint. The
+// mint's own authority is a PDA that signs unconditionally, so this account is
+// the only thing gating who may trigger it.
+#[account]
+pub struct MintConfig {
+    pub admin: Pubkey,
+}
+
+impl MintConfig {
+    pub const LEN: usize = 8 + 32;
+}

--- a/tokens/pda-mint-authority/anchor/tests/litesvm.test.ts
+++ b/tokens/pda-mint-authority/anchor/tests/litesvm.test.ts
@@ -1,10 +1,22 @@
 import * as anchor from '@anchor-lang/core';
 import { getAssociatedTokenAddressSync } from '@solana/spl-token';
-import { PublicKey } from '@solana/web3.js';
+import { Keypair, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
+import { assert } from 'chai';
 import { LiteSVMProvider } from 'anchor-litesvm';
 import { LiteSVM } from 'litesvm';
 import IDL from '../target/idl/token_minter.json';
 import type { TokenMinter } from '../target/types/token_minter';
+
+const expectAnchorError = async (promise: Promise<unknown>, code: string) => {
+    let caught: any;
+    try {
+        await promise;
+    } catch (error) {
+        caught = error;
+    }
+    assert.isDefined(caught, `expected the transaction to fail with ${code}`);
+    assert.strictEqual(caught?.error?.errorCode?.code, code, `expected ${code}, got: ${caught}`);
+};
 
 const PROGRAM_ID = new PublicKey(IDL.address);
 const METADATA_PROGRAM_ID = new PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');
@@ -59,5 +71,23 @@ describe('NFT Minter', () => {
         console.log('Success!');
         console.log(`   Associated Token Account Address: ${associatedTokenAccountAddress}`);
         console.log(`   Transaction Signature: ${transactionSignature}`);
+    });
+
+    it('rejects mint_token from a wallet that did not create the token', async () => {
+        const outsider = Keypair.generate();
+        client.airdrop(outsider.publicKey, BigInt(LAMPORTS_PER_SOL));
+        const outsiderAta = getAssociatedTokenAddressSync(mintPDA, outsider.publicKey);
+
+        await expectAnchorError(
+            program.methods
+                .mintToken(new anchor.BN(100))
+                .accountsPartial({
+                    payer: outsider.publicKey,
+                    associatedTokenAccount: outsiderAta,
+                })
+                .signers([outsider])
+                .rpc(),
+            'Unauthorized',
+        );
     });
 });


### PR DESCRIPTION
## Summary

`tokens/pda-mint-authority` (anchor) has an unrestricted-minting vulnerability: `mint_token`
performs **no authorization check whatsoever**. Its only accounts are `payer: Signer` (any
wallet) and the mint/ATA accounts — the mint's authority is a program-derived PDA
(`seeds = [b"mint"]`, set up in `create_token`) that signs the `MintTo` CPI unconditionally
on every call, for whoever happens to call the instruction.

`create_token` uses Anchor's `init` constraint, so the mint is created exactly once,
globally, as a plain SPL fungible token (`mint::decimals = 9`, no supply cap, no Metaplex
Master Edition). Combined with the missing check on `mint_token`, **any wallet can mint an
arbitrary amount of this token to itself, repeatedly, forever** — unrestricted token supply
inflation, with no cap and no gate.

### Why this went unnoticed

- The README says only *"This example is exactly the same as the NFT Minter example, but it
  changes the mint authority account from the payer to a PDA"* — no caveat about missing
  access control (unlike this repo's `compression/cnft-vault`, which explicitly discloses
  its own analogous gap as an intentional proof-of-concept limitation).
- `create.rs`'s own comment frames the PDA-as-signer mechanic as the sole teaching point:
  *"demonstrate that the same PDA can be used for both the address of an account and CPI
  signing."* Access control was never part of the design discussion.
- The sibling `native` and `pinocchio` implementations of this same example mint an **NFT**
  (supply 1), then hand the mint/freeze authority to a Metaplex Master Edition PDA — which
  incidentally caps them at one mint per account, even without an explicit check. The
  **anchor** implementation departs from this (plain fungible token, no edition, no cap) and
  is the only one of the three with unbounded, repeatable minting.
- The existing test only ever calls `mint_token` as the same wallet that called
  `create_token` — there is no test with a second, unrelated caller, so the missing check
  had zero coverage.

## Fix

Adds a `MintConfig` PDA (`seeds = [b"mint_config"]`) that records the admin (the wallet that
called `create_token`) and gates `mint_token` behind it via an Anchor account-level
constraint (`mint_config.admin == payer.key()`). The existing "PDA is both the mint account
address and the CPI signer" demonstration — the example's actual teaching point — is
completely untouched; this only adds a small, separate, read-only-checked account
controlling who may trigger the existing mint logic.

## Test changes

Added a negative test in `tests/litesvm.test.ts`: a second, freshly-generated wallet
attempts `mint_token` after the first wallet's `create_token`, asserting it fails with
`Unauthorized`. Verified this reproduces against the unpatched code (reverted the fix,
rebuilt, confirmed the unrelated wallet's mint call *succeeds*), then reapplied the fix and
confirmed it's correctly rejected. The two pre-existing tests pass unchanged — Anchor's
client-side PDA auto-resolution picks up the new `mint_config` account without needing
explicit wiring in `.accountsPartial(...)`.

## Out of scope

- The native/pinocchio siblings have a different, lower-severity, related concern: since
  `create` and `mint_to` are separate instructions, any caller can crank the one-time
  `mint_to` before the intended recipient, directing a single NFT to themselves instead.
  This is bounded to one NFT per mint account and requires timing/front-running, unlike the
  anchor bug's unbounded, un-timed value creation — flagging it here for visibility, not
  fixing it in this PR.
- `compression/cnft-vault`'s missing access control is a disclosed, intentional limitation
  per its own README and not something this audit should "fix" against the authors' stated
  intent.

## Verification

- `cargo check`, `anchor build`, `cargo fmt -p pda-mint-authority-anchor` (scoped — this
  crate is listed in `.github/.workspace-ignore`), `pnpm exec tsc --noEmit`, root
  `prettier --check` all pass.
- Full `litesvm.test.ts` suite: 3/3 passing.
- Red/green proof: captured the fix as a patch, reverted the program source only, rebuilt,
  confirmed the new negative test fails against the unpatched code (an unrelated wallet's
  mint succeeds), reapplied the patch, confirmed the full suite passes green.