### PR TITLE
fix(transfer-tokens): native transfer wrongly requires the recipient to co-sign

### DIFF
--- a/tokens/transfer-tokens/native/program/src/instructions/transfer.rs
+++ b/tokens/transfer-tokens/native/program/src/instructions/transfer.rs
@@ -62,10 +62,8 @@ pub fn transfer_tokens(accounts: &[AccountInfo], args: TransferTokensArgs) -> Pr
             from_associated_token_account.key,
             to_associated_token_account.key,
             owner.key,
-            // Empty: `owner` is a plain wallet authority, not a multisig account.
-            // A non-empty list here marks `owner` as non-signer and instead
-            // requires each listed pubkey to co-sign as a multisig member — which
-            // wrongly forced the recipient to sign just to receive tokens.
+            // Empty: `owner` is a single signer, not a multisig — a non-empty
+            // list here wrongly required the recipient to also sign.
             &[],
             args.quantity,
         )?,

--- a/tokens/transfer-tokens/native/program/src/instructions/transfer.rs
+++ b/tokens/transfer-tokens/native/program/src/instructions/transfer.rs
@@ -62,7 +62,11 @@ pub fn transfer_tokens(accounts: &[AccountInfo], args: TransferTokensArgs) -> Pr
             from_associated_token_account.key,
             to_associated_token_account.key,
             owner.key,
-            &[owner.key, recipient.key],
+            // Empty: `owner` is a plain wallet authority, not a multisig account.
+            // A non-empty list here marks `owner` as non-signer and instead
+            // requires each listed pubkey to co-sign as a multisig member — which
+            // wrongly forced the recipient to sign just to receive tokens.
+            &[],
             args.quantity,
         )?,
         &[

--- a/tokens/transfer-tokens/native/tests/test.ts
+++ b/tokens/transfer-tokens/native/tests/test.ts
@@ -216,7 +216,7 @@ describe('Transferring Tokens', () => {
             await findAssociatedTokenAddress(mint, payer.address),
             await findAssociatedTokenAddress(mint, recipientWallet.address),
             payer,
-            recipientWallet,
+            recipientWallet.address,
             payer,
             programId,
             quantity,

--- a/tokens/transfer-tokens/native/ts/instructions/transfer.ts
+++ b/tokens/transfer-tokens/native/ts/instructions/transfer.ts
@@ -21,7 +21,7 @@ export function createTransferTokensInstruction(
     fromAssociatedTokenAccount: Address,
     toAssociatedTokenAccount: Address,
     owner: TransactionSigner,
-    recipient: TransactionSigner,
+    recipient: Address,
     payer: TransactionSigner,
     programId: Address,
     quantity: bigint,
@@ -33,7 +33,9 @@ export function createTransferTokensInstruction(
             { address: fromAssociatedTokenAccount, role: AccountRole.WRITABLE },
             { address: toAssociatedTokenAccount, role: AccountRole.WRITABLE },
             { address: owner.address, role: AccountRole.WRITABLE_SIGNER, signer: owner },
-            { address: recipient.address, role: AccountRole.WRITABLE_SIGNER, signer: recipient },
+            // Recipient just needs to be named, not to sign — receiving tokens
+            // must never require the recipient's approval.
+            { address: recipient, role: AccountRole.READONLY },
             { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
             { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
             { address: TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY },


### PR DESCRIPTION
## The bug

The `native` implementation of `tokens/transfer-tokens`'s `transfer_tokens` instruction builds the SPL Token `Transfer` CPI like this:

```rust
&token_instruction::transfer(
    token_program.key,
    from_associated_token_account.key,
    to_associated_token_account.key,
    owner.key,
    &[owner.key, recipient.key],   // <- signer_pubkeys
    args.quantity,
)?,
```

Passing a non-empty `signer_pubkeys` list tells the SPL Token program the `authority` account (`owner`) is a **multisig** account, and marks `owner` itself as a non-signer in the CPI's account metas — the listed pubkeys (`owner`, `recipient`) are appended as the individual co-signers of that multisig instead. `owner` here is just a plain wallet, not a multisig account, so this construction is wrong regardless of who calls it.

**Concrete effect, confirmed empirically:** a transfer only succeeds if the *recipient* also signs the transaction. Without it, the CPI is rejected at the runtime privilege-check stage before the Token program even runs:

```
"Ar4ej...'s signer privilege escalated"
"... failed: Cross-program invocation with unauthorized signer or writable account"
```

This is backwards — a recipient should never need to approve/co-sign to *receive* tokens sent to them. As shipped, this example teaches a pattern that makes tokens effectively impossible to transfer to any wallet that isn't present to co-sign, which defeats the purpose of the instruction. The existing test suite didn't catch this because it happened to make the recipient a signer for unrelated reasons (its account needed funding to test with).

The `anchor` and `pinocchio` implementations of this same example were already correct (`signer_pubkeys: &[]` in pinocchio, and Anchor's `Transfer` CPI simply never lists `recipient` as an authority) — only `native` had this bug.

## Fix

Pass an empty `signer_pubkeys` list, matching `owner`'s actual role as a plain single-signer authority — the same pattern already used by the `anchor` and `pinocchio` versions. Updated the TS instruction builder (`ts/instructions/transfer.ts`) to take the recipient as a plain `Address` instead of a `TransactionSigner`, and updated the test to pass the recipient's address without asking it to sign.

## Verification

- Confirmed red/green: reverted just the `signer_pubkeys` fix (keeping the updated, non-signing-recipient test), rebuilt, and confirmed the transfer tests fail with `Cross-program invocation with unauthorized signer or writable account` — then reapplied the fix and confirmed all 6 tests pass.
- Full `native` litesvm suite passes (`Create an SPL Token!`, `Create an NFT!`, `Mint some tokens to your wallet!`, `Mint the NFT to your wallet!`, `Transfer tokens to another wallet!`, `Transfer NFT to another wallet!`).
- `cargo fmt -p transfer-tokens-program -- --check` and `cargo clippy -p transfer-tokens-program --all-targets -- -D warnings` both clean.
- `tsc --noEmit` and repo-wide `prettier --check` both clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)