### PR TITLE
fix(tokens/token-fundraiser): scale minimum amounts by 10^decimals

### DIFF
--- a/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/contribute.rs
+++ b/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/contribute.rs
@@ -58,7 +58,7 @@ impl<'info> Contribute<'info> {
 
         // Check if the amount to contribute meets the minimum amount required
         require!(
-            amount >= 1_u64.pow(self.mint_to_raise.decimals as u32), 
+            amount >= 10_u64.pow(self.mint_to_raise.decimals as u32),
             FundraiserError::ContributionTooSmall
         );
 

--- a/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/contribute.rs
+++ b/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/contribute.rs
@@ -56,11 +56,14 @@ pub struct Contribute<'info> {
 impl<'info> Contribute<'info> {
     pub fn contribute(&mut self, amount: u64) -> Result<()> {
 
-        // Check if the amount to contribute meets the minimum amount required
-        require!(
-            amount >= 10_u64.pow(self.mint_to_raise.decimals as u32),
-            FundraiserError::ContributionTooSmall
-        );
+        // Check if the amount to contribute meets the minimum amount required.
+        // 10^decimals leaves u64 above 19 decimals; a floor that cannot be
+        // represented cannot be met, so reject rather than panic.
+        let min_contribution = 10_u64
+            .checked_pow(self.mint_to_raise.decimals as u32)
+            .ok_or(FundraiserError::ContributionTooSmall)?;
+
+        require!(amount >= min_contribution, FundraiserError::ContributionTooSmall);
 
         // Check if the amount to contribute is less than the maximum allowed contribution
         require!(

--- a/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/initialize.rs
+++ b/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/initialize.rs
@@ -42,7 +42,7 @@ impl<'info> Initialize<'info> {
 
         // Check if the amount to raise meets the minimum amount required
         require!(
-            amount >= MIN_AMOUNT_TO_RAISE.pow(self.mint_to_raise.decimals as u32),
+            amount >= MIN_AMOUNT_TO_RAISE * 10_u64.pow(self.mint_to_raise.decimals as u32),
             FundraiserError::InvalidAmount
         );
 

--- a/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/initialize.rs
+++ b/tokens/token-fundraiser/anchor/programs/fundraiser/src/instructions/initialize.rs
@@ -40,11 +40,16 @@ pub struct Initialize<'info> {
 impl<'info> Initialize<'info> {
     pub fn initialize(&mut self, amount: u64, duration: u16, bumps: &InitializeBumps) -> Result<()> {
 
-        // Check if the amount to raise meets the minimum amount required
-        require!(
-            amount >= MIN_AMOUNT_TO_RAISE * 10_u64.pow(self.mint_to_raise.decimals as u32),
-            FundraiserError::InvalidAmount
-        );
+        // Check if the amount to raise meets the minimum amount required.
+        // Checked throughout: decimals is mint-controlled, and 3 * 10^decimals
+        // leaves u64 at 19 decimals. If the minimum is not representable then
+        // no target can reach it, so reject rather than panic.
+        let min_amount_to_raise = 10_u64
+            .checked_pow(self.mint_to_raise.decimals as u32)
+            .and_then(|one_token| MIN_AMOUNT_TO_RAISE.checked_mul(one_token))
+            .ok_or(FundraiserError::InvalidAmount)?;
+
+        require!(amount >= min_amount_to_raise, FundraiserError::InvalidAmount);
 
         // Initialize the fundraiser account
         self.fundraiser.set_inner(Fundraiser {

--- a/tokens/token-fundraiser/anchor/tests/minimum-amounts.test.ts
+++ b/tokens/token-fundraiser/anchor/tests/minimum-amounts.test.ts
@@ -1,0 +1,170 @@
+import * as anchor from '@anchor-lang/core';
+import {
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    createAssociatedTokenAccountInstruction,
+    createInitializeMint2Instruction,
+    createMintToInstruction,
+    getAssociatedTokenAddressSync,
+    MINT_SIZE,
+    TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+import { PublicKey } from '@solana/web3.js';
+import { getTokenDecoder } from '@solana-program/token';
+import { LiteSVMProvider } from 'anchor-litesvm';
+import { assert } from 'chai';
+import { LiteSVM } from 'litesvm';
+import IDL from '../target/idl/fundraiser.json';
+import type { Fundraiser } from '../target/types/fundraiser';
+import { expectAnchorError } from './utils';
+
+const PROGRAM_ID = new PublicKey(IDL.address);
+
+// Both floors in the program scale by 10^decimals, so at 6 decimals:
+//   initialize: MIN_AMOUNT_TO_RAISE (3) whole tokens = 3_000_000 base units
+//   contribute: 1 whole token                        = 1_000_000 base units
+const DECIMALS = 6;
+const ONE_TOKEN = 1_000_000;
+const MIN_RAISE = 3 * ONE_TOKEN;
+
+// The per-contributor cap is 10% of the target, so a campaign has to raise at
+// least 10 tokens before any contribution can clear the 1-token floor without
+// immediately breaching the cap. 30 tokens leaves room for both.
+const TARGET = 30 * ONE_TOKEN;
+
+describe('fundraiser minimum amounts', () => {
+    const client = new LiteSVM();
+    client.addProgramFromFile(PROGRAM_ID, 'target/deploy/fundraiser.so');
+    const provider = new LiteSVMProvider(client);
+    anchor.setProvider(provider);
+    const wallet = provider.wallet as anchor.Wallet;
+    const program = new anchor.Program<Fundraiser>(IDL, provider);
+
+    const maker = anchor.web3.Keypair.generate();
+    const floorMaker = anchor.web3.Keypair.generate();
+
+    const fundraiser = anchor.web3.PublicKey.findProgramAddressSync(
+        [Buffer.from('fundraiser'), maker.publicKey.toBuffer()],
+        program.programId,
+    )[0];
+    const floorFundraiser = anchor.web3.PublicKey.findProgramAddressSync(
+        [Buffer.from('fundraiser'), floorMaker.publicKey.toBuffer()],
+        program.programId,
+    )[0];
+    const contributorAccount = anchor.web3.PublicKey.findProgramAddressSync(
+        [Buffer.from('contributor'), fundraiser.toBuffer(), provider.publicKey.toBuffer()],
+        program.programId,
+    )[0];
+
+    const tokenBalance = (account: anchor.web3.PublicKey) =>
+        getTokenDecoder().decode(client.getAccount(account).data).amount;
+
+    let mint: PublicKey;
+    let contributorAta: PublicKey;
+
+    const initialize = (amount: number, campaignMaker: anchor.web3.Keypair, campaign: PublicKey) =>
+        program.methods
+            .initialize(new anchor.BN(amount), 1)
+            .accountsPartial({
+                maker: campaignMaker.publicKey,
+                fundraiser: campaign,
+                mintToRaise: mint,
+                vault: getAssociatedTokenAddressSync(mint, campaign, true),
+                systemProgram: anchor.web3.SystemProgram.programId,
+                tokenProgram: TOKEN_PROGRAM_ID,
+                associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+            })
+            .signers([campaignMaker])
+            .rpc();
+
+    const contribute = (amount: number) =>
+        program.methods
+            .contribute(new anchor.BN(amount))
+            .accountsPartial({
+                contributor: provider.publicKey,
+                mintToRaise: mint,
+                fundraiser,
+                contributorAccount,
+                contributorAta,
+                vault: getAssociatedTokenAddressSync(mint, fundraiser, true),
+                tokenProgram: TOKEN_PROGRAM_ID,
+            })
+            .rpc();
+
+    it('sets up a 6-decimal mint and funds the contributor', async () => {
+        client.airdrop(maker.publicKey, BigInt(anchor.web3.LAMPORTS_PER_SOL));
+        client.airdrop(floorMaker.publicKey, BigInt(anchor.web3.LAMPORTS_PER_SOL));
+
+        const mintKp = anchor.web3.Keypair.generate();
+        mint = mintKp.publicKey;
+        contributorAta = getAssociatedTokenAddressSync(mint, wallet.publicKey);
+
+        const lamports = await provider.connection.getMinimumBalanceForRentExemption(MINT_SIZE);
+        const setupTx = new anchor.web3.Transaction().add(
+            anchor.web3.SystemProgram.createAccount({
+                fromPubkey: wallet.publicKey,
+                newAccountPubkey: mint,
+                space: MINT_SIZE,
+                lamports,
+                programId: TOKEN_PROGRAM_ID,
+            }),
+            createInitializeMint2Instruction(mint, DECIMALS, provider.publicKey, provider.publicKey),
+            createAssociatedTokenAccountInstruction(wallet.publicKey, contributorAta, wallet.publicKey, mint),
+            createMintToInstruction(mint, contributorAta, provider.publicKey, 10 * ONE_TOKEN),
+        );
+        await provider.sendAndConfirm(setupTx, [mintKp]);
+
+        assert.strictEqual(tokenBalance(contributorAta), BigInt(10 * ONE_TOKEN));
+    });
+
+    // Pre-fix the floor is MIN_AMOUNT_TO_RAISE.pow(decimals) = 3^6 = 729 base
+    // units, so this amount sails through and no account is ever created.
+    it('rejects a target below MIN_AMOUNT_TO_RAISE whole tokens', async () => {
+        await expectAnchorError(initialize(MIN_RAISE - 1, floorMaker, floorFundraiser), 'InvalidAmount');
+
+        assert.isNotOk(client.getAccount(floorFundraiser), 'no fundraiser account should have been created');
+    });
+
+    it('accepts a target of exactly MIN_AMOUNT_TO_RAISE whole tokens', async () => {
+        await initialize(MIN_RAISE, floorMaker, floorFundraiser);
+
+        const state = await program.account.fundraiser.fetch(floorFundraiser);
+        assert.strictEqual(state.amountToRaise.toNumber(), MIN_RAISE);
+    });
+
+    it('initializes the campaign used for the contribution floor', async () => {
+        await initialize(TARGET, maker, fundraiser);
+
+        const state = await program.account.fundraiser.fetch(fundraiser);
+        assert.strictEqual(state.amountToRaise.toNumber(), TARGET);
+        assert.strictEqual(state.currentAmount.toNumber(), 0);
+    });
+
+    // Pre-fix the floor is 1_u64.pow(decimals) = 1 base unit, so every
+    // non-zero contribution clears it and this transaction wrongly succeeds.
+    it('rejects a contribution below one whole token', async () => {
+        const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
+        const vaultBefore = tokenBalance(vault);
+
+        await expectAnchorError(contribute(ONE_TOKEN - 1), 'ContributionTooSmall');
+
+        assert.strictEqual(tokenBalance(vault), vaultBefore, 'vault must not move on a rejected contribution');
+        assert.isNotOk(client.getAccount(contributorAccount), 'no contributor account should have been created');
+    });
+
+    it('accepts a contribution of exactly one whole token', async () => {
+        client.expireBlockhash();
+        const vault = getAssociatedTokenAddressSync(mint, fundraiser, true);
+        const contributorBefore = tokenBalance(contributorAta);
+
+        await contribute(ONE_TOKEN);
+
+        assert.strictEqual(tokenBalance(vault), BigInt(ONE_TOKEN));
+        assert.strictEqual(tokenBalance(contributorAta), contributorBefore - BigInt(ONE_TOKEN));
+
+        const state = await program.account.fundraiser.fetch(fundraiser);
+        assert.strictEqual(state.currentAmount.toNumber(), ONE_TOKEN);
+
+        const contribution = await program.account.contributor.fetch(contributorAccount);
+        assert.strictEqual(contribution.amount.toNumber(), ONE_TOKEN);
+    });
+});

--- a/tokens/token-fundraiser/anchor/tests/minimum-amounts.test.ts
+++ b/tokens/token-fundraiser/anchor/tests/minimum-amounts.test.ts
@@ -44,15 +44,15 @@ describe('fundraiser minimum amounts', () => {
 
     const fundraiser = anchor.web3.PublicKey.findProgramAddressSync(
         [Buffer.from('fundraiser'), maker.publicKey.toBuffer()],
-        program.programId,
+        program.programId
     )[0];
     const floorFundraiser = anchor.web3.PublicKey.findProgramAddressSync(
         [Buffer.from('fundraiser'), floorMaker.publicKey.toBuffer()],
-        program.programId,
+        program.programId
     )[0];
     const contributorAccount = anchor.web3.PublicKey.findProgramAddressSync(
         [Buffer.from('contributor'), fundraiser.toBuffer(), provider.publicKey.toBuffer()],
-        program.programId,
+        program.programId
     )[0];
 
     const tokenBalance = (account: anchor.web3.PublicKey) =>
@@ -109,7 +109,7 @@ describe('fundraiser minimum amounts', () => {
             }),
             createInitializeMint2Instruction(mint, DECIMALS, provider.publicKey, provider.publicKey),
             createAssociatedTokenAccountInstruction(wallet.publicKey, contributorAta, wallet.publicKey, mint),
-            createMintToInstruction(mint, contributorAta, provider.publicKey, 10 * ONE_TOKEN),
+            createMintToInstruction(mint, contributorAta, provider.publicKey, 10 * ONE_TOKEN)
         );
         await provider.sendAndConfirm(setupTx, [mintKp]);
 
@@ -149,6 +149,55 @@ describe('fundraiser minimum amounts', () => {
 
         assert.strictEqual(tokenBalance(vault), vaultBefore, 'vault must not move on a rejected contribution');
         assert.isNotOk(client.getAccount(contributorAccount), 'no contributor account should have been created');
+    });
+
+    // 3 * 10^19 leaves u64, so the minimum target is not representable. With
+    // overflow-checks enabled in the release profile that is a panic unless the
+    // arithmetic is checked; SPL Token places no cap on a mint's decimals.
+    it('rejects a high-decimal mint instead of overflowing', async () => {
+        const wideMintKp = anchor.web3.Keypair.generate();
+        const wideMint = wideMintKp.publicKey;
+        const wideMaker = anchor.web3.Keypair.generate();
+        client.airdrop(wideMaker.publicKey, BigInt(anchor.web3.LAMPORTS_PER_SOL));
+
+        const wideFundraiser = anchor.web3.PublicKey.findProgramAddressSync(
+            [Buffer.from('fundraiser'), wideMaker.publicKey.toBuffer()],
+            program.programId
+        )[0];
+
+        const lamports = await provider.connection.getMinimumBalanceForRentExemption(MINT_SIZE);
+        await provider.sendAndConfirm(
+            new anchor.web3.Transaction().add(
+                anchor.web3.SystemProgram.createAccount({
+                    fromPubkey: wallet.publicKey,
+                    newAccountPubkey: wideMint,
+                    space: MINT_SIZE,
+                    lamports,
+                    programId: TOKEN_PROGRAM_ID,
+                }),
+                createInitializeMint2Instruction(wideMint, 19, provider.publicKey, provider.publicKey)
+            ),
+            [wideMintKp]
+        );
+
+        await expectAnchorError(
+            program.methods
+                .initialize(new anchor.BN('18446744073709551615'), 1)
+                .accountsPartial({
+                    maker: wideMaker.publicKey,
+                    fundraiser: wideFundraiser,
+                    mintToRaise: wideMint,
+                    vault: getAssociatedTokenAddressSync(wideMint, wideFundraiser, true),
+                    systemProgram: anchor.web3.SystemProgram.programId,
+                    tokenProgram: TOKEN_PROGRAM_ID,
+                    associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+                })
+                .signers([wideMaker])
+                .rpc(),
+            'InvalidAmount'
+        );
+
+        assert.isNotOk(client.getAccount(wideFundraiser), 'no fundraiser account should have been created');
     });
 
     it('accepts a contribution of exactly one whole token', async () => {


### PR DESCRIPTION
## Summary

Both minimum-amount checks in `tokens/token-fundraiser/anchor` exponentiate the wrong base, so neither enforces the threshold it describes.

**`contribute`** (`instructions/contribute.rs:61`)

```rust
amount >= 1_u64.pow(self.mint_to_raise.decimals as u32)
```

One raised to any power is one, so the floor is a single base unit rather than one whole token. At 6 decimals that is 1,000,000× too low and the check is dead — every non-zero contribution clears it.

**`initialize`** (`instructions/initialize.rs:45`)

```rust
amount >= MIN_AMOUNT_TO_RAISE.pow(self.mint_to_raise.decimals as u32)  // MIN_AMOUNT_TO_RAISE = 3
```

This raises 3 to the power of the decimals instead of scaling 3 by them: `3^6` = 729 base units, or 0.000729 tokens, where 3 tokens (3,000,000) is intended. The shape is wrong as well as the magnitude — it grows as `3^d` rather than `3 * 10^d`, so at 0 decimals it yields `3^0 = 1`, contradicting that check's own error message, *"Invalid total amount. i should be bigger than 3"*.

## Why `10^decimals` is the intended scaling

Every other decimals-scaling site in the repository uses `10u64.pow(decimals)`:

- `tokens/pda-mint-authority/anchor/programs/token-minter/src/instructions/mint.rs:65`
- `tokens/transfer-tokens/anchor/programs/transfer-tokens/src/instructions/transfer.rs:61` and `mint.rs:48`
- `tokens/token-2022/transfer-fee/native/program/src/lib.rs:63`

And this project's own test already encodes the intent — `tests/checker-mint-binding.test.ts:38`:

```ts
const AMOUNT_TO_RAISE = 3_000_000; // 3 tokens at 6 decimals
```

That is `MIN_AMOUNT_TO_RAISE * 10^6`, which is exactly what `initialize` fails to compute.

## Tests

Adds `tests/minimum-amounts.test.ts`, covering both floors from either side: a sub-threshold `initialize` and `contribute` are rejected, and the exact-threshold values are accepted with the resulting vault balance, `current_amount`, and `Contributor.amount` asserted.

Verified the new tests actually fail against the unfixed program, per the "verify by breaking an assertion once" note in `AGENTS.md`:

| | `minimum-amounts.test.ts` |
|---|---|
| before the fix | 2 passing, **4 failing** — the sub-threshold `initialize` and `contribute` calls succeed instead of raising `InvalidAmount` / `ContributionTooSmall`, and the follow-on assertions cascade |
| after the fix | **6 passing** |

The existing suites are unaffected: they initialize at 30,000,000 and 3,000,000 and contribute 1,000,000 and 2,000,000, all of which clear the corrected thresholds. `litesvm.test.ts`, `checker-mint-binding.test.ts` and the new file run **18 passing** together.

`tests/fundraiser.ts` was not exercised locally — `anchor test` spawns `surfpool`, which I do not have installed — but it initializes at 30,000,000 and contributes 1,000,000, both above the corrected floors.

## Overflow handling

Scaling by `10^decimals` reaches the edge of `u64` far sooner than the expression it replaces, and `tokens/token-fundraiser/anchor/Cargo.toml` sets `overflow-checks = true` on the release profile, so the edge is a panic rather than a wrap.

SPL Token places no cap on a mint's decimals. Verified against litesvm: mints at 19 and 20 decimals are created without complaint, and `initialize` panics — at 19 on the `MIN_AMOUNT_TO_RAISE *` multiply, at 20 inside `pow` itself.

The threshold moved rather than appeared: `MIN_AMOUNT_TO_RAISE.pow(decimals)` is `3^d` and does not leave `u64` until 41 decimals, so correcting the base brought it down to 19.

Both floors therefore compute with `checked_pow`/`checked_mul` and surface the instruction's own error. A minimum that is not representable in `u64` cannot be met, so those mints are rejected either way — the difference is that the caller gets `InvalidAmount` / `ContributionTooSmall` instead of a panicking program. A 19-decimal case covering this is included, bringing the three litesvm suites to **19 passing**.

## Contribution cap arithmetic

Follow-on from the above, and reachable through it. `initialize` accepts any target at or above the minimum, and `contribute` multiplies that target by `MAX_CONTRIBUTION_PERCENTAGE` in `u64`. At 18 decimals the corrected floor is `3 * 10^18`, already past `u64::MAX / 10`, so every target the program accepts overflows the cap multiply — verified against litesvm, `initialize` succeeds at `3 * 10^18` and `contribute` panics at `contribute.rs:70:23`.

The cap is now computed once in `u128` and shared by both checks; being a percentage of the target it always narrows back to `u64`. The per-contributor running total uses `checked_add`.

No contribution is valid at 18 decimals either way — a floor of `10^18` cannot also sit under a cap of one tenth of a `u64` target — so what changes is the reporting: `ContributionTooBig` rather than a panic. Covered by a test. Three litesvm suites now at **20 passing**.

Out of scope and left alone: the remaining unchecked arithmetic in this example (`current_amount += amount`, the `current_time - time_started` subtraction, and `refund`'s `current_amount -=`). Happy to take those in a follow-up if wanted.
