### PR TITLE
chore: fix deploy artifact path in example build scripts

### DIFF
--- a/basics/account-data/native/cicd.sh
+++ b/basics/account-data/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/account-data/native/package.json
+++ b/basics/account-data/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/account-data/pinocchio/cicd.sh
+++ b/basics/account-data/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/checking-accounts/native/cicd.sh
+++ b/basics/checking-accounts/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/checking-accounts/native/package.json
+++ b/basics/checking-accounts/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/checking-accounts/pinocchio/cicd.sh
+++ b/basics/checking-accounts/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/checking-accounts/pinocchio/package.json
+++ b/basics/checking-accounts/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/close-account/native/cicd.sh
+++ b/basics/close-account/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/close-account/native/package.json
+++ b/basics/close-account/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/close-account.test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/close-account/pinocchio/cicd.sh
+++ b/basics/close-account/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/close-account/pinocchio/package.json
+++ b/basics/close-account/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/close-account.test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/counter/native/package.json
+++ b/basics/counter/native/package.json
@@ -11,7 +11,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/counter.test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/basics/counter/pinocchio/package.json
+++ b/basics/counter/pinocchio/package.json
@@ -11,7 +11,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/counter.test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/basics/create-account/native/cicd.sh
+++ b/basics/create-account/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/create-account/native/package.json
+++ b/basics/create-account/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/create-account/pinocchio/cicd.sh
+++ b/basics/create-account/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/create-account/pinocchio/package.json
+++ b/basics/create-account/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/favorites/native/cicd.sh
+++ b/basics/favorites/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/favorites/native/package.json
+++ b/basics/favorites/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/favorites/pinocchio/cicd.sh
+++ b/basics/favorites/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/favorites/pinocchio/package.json
+++ b/basics/favorites/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/hello-solana/native/cicd.sh
+++ b/basics/hello-solana/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/hello-solana/pinocchio/cicd.sh
+++ b/basics/hello-solana/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/pda-rent-payer/native/cicd.sh
+++ b/basics/pda-rent-payer/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/pda-rent-payer/native/package.json
+++ b/basics/pda-rent-payer/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/pda-rent-payer/pinocchio/cicd.sh
+++ b/basics/pda-rent-payer/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/pda-rent-payer/pinocchio/package.json
+++ b/basics/pda-rent-payer/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/processing-instructions/native/cicd.sh
+++ b/basics/processing-instructions/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/processing-instructions/native/package.json
+++ b/basics/processing-instructions/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0"

--- a/basics/processing-instructions/pinocchio/cicd.sh
+++ b/basics/processing-instructions/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/processing-instructions/pinocchio/package.json
+++ b/basics/processing-instructions/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0"

--- a/basics/program-derived-addresses/native/cicd.sh
+++ b/basics/program-derived-addresses/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/program-derived-addresses/native/package.json
+++ b/basics/program-derived-addresses/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/program-derived-addresses/pinocchio/cicd.sh
+++ b/basics/program-derived-addresses/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/program-derived-addresses/pinocchio/package.json
+++ b/basics/program-derived-addresses/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/realloc/native/cicd.sh
+++ b/basics/realloc/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/realloc/native/package.json
+++ b/basics/realloc/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/realloc.test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/realloc/pinocchio/cicd.sh
+++ b/basics/realloc/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/realloc/pinocchio/package.json
+++ b/basics/realloc/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/realloc.test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/repository-layout/native/cicd.sh
+++ b/basics/repository-layout/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/repository-layout/native/package.json
+++ b/basics/repository-layout/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0"

--- a/basics/repository-layout/pinocchio/cicd.sh
+++ b/basics/repository-layout/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/repository-layout/pinocchio/package.json
+++ b/basics/repository-layout/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0"

--- a/basics/transfer-sol/native/cicd.sh
+++ b/basics/transfer-sol/native/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/transfer-sol/native/package.json
+++ b/basics/transfer-sol/native/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/basics/transfer-sol/pinocchio/cicd.sh
+++ b/basics/transfer-sol/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/basics/transfer-sol/pinocchio/package.json
+++ b/basics/transfer-sol/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana/kit": "^7.0.0",

--- a/tokens/create-token/pinocchio/cicd.sh
+++ b/tokens/create-token/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/create-token/pinocchio/package.json
+++ b/tokens/create-token/pinocchio/package.json
@@ -5,7 +5,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/escrow/native/package.json
+++ b/tokens/escrow/native/package.json
@@ -3,7 +3,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.13.0",

--- a/tokens/escrow/pinocchio/cicd.sh
+++ b/tokens/escrow/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/escrow/pinocchio/package.json
+++ b/tokens/escrow/pinocchio/package.json
@@ -3,7 +3,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/nft-operations/pinocchio/cicd.sh
+++ b/tokens/nft-operations/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/nft-operations/pinocchio/package.json
+++ b/tokens/nft-operations/pinocchio/package.json
@@ -5,7 +5,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/pda-mint-authority/pinocchio/cicd.sh
+++ b/tokens/pda-mint-authority/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/pda-mint-authority/pinocchio/package.json
+++ b/tokens/pda-mint-authority/pinocchio/package.json
@@ -5,7 +5,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/token-2022/default-account-state/pinocchio/cicd.sh
+++ b/tokens/token-2022/default-account-state/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/token-2022/default-account-state/pinocchio/package.json
+++ b/tokens/token-2022/default-account-state/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/token-2022/immutable-owner/pinocchio/cicd.sh
+++ b/tokens/token-2022/immutable-owner/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/token-2022/immutable-owner/pinocchio/package.json
+++ b/tokens/token-2022/immutable-owner/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/token-2022/interest-bearing/pinocchio/cicd.sh
+++ b/tokens/token-2022/interest-bearing/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/token-2022/interest-bearing/pinocchio/package.json
+++ b/tokens/token-2022/interest-bearing/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/token-2022/mint-close-authority/native/package.json
+++ b/tokens/token-2022/mint-close-authority/native/package.json
@@ -3,7 +3,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/token-2022/mint-close-authority/pinocchio/cicd.sh
+++ b/tokens/token-2022/mint-close-authority/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/token-2022/mint-close-authority/pinocchio/package.json
+++ b/tokens/token-2022/mint-close-authority/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/token-2022/multiple-extensions/pinocchio/cicd.sh
+++ b/tokens/token-2022/multiple-extensions/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/token-2022/multiple-extensions/pinocchio/package.json
+++ b/tokens/token-2022/multiple-extensions/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/token-2022/non-transferable/pinocchio/cicd.sh
+++ b/tokens/token-2022/non-transferable/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/token-2022/non-transferable/pinocchio/package.json
+++ b/tokens/token-2022/non-transferable/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/token-2022/permanent-delegate/pinocchio/cicd.sh
+++ b/tokens/token-2022/permanent-delegate/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/token-2022/permanent-delegate/pinocchio/package.json
+++ b/tokens/token-2022/permanent-delegate/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/token-2022/transfer-fee/pinocchio/cicd.sh
+++ b/tokens/token-2022/transfer-fee/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/token-2022/transfer-fee/pinocchio/package.json
+++ b/tokens/token-2022/transfer-fee/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",

--- a/tokens/transfer-tokens/pinocchio/cicd.sh
+++ b/tokens/transfer-tokens/pinocchio/cicd.sh
@@ -5,4 +5,4 @@
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
 cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
-solana program deploy ./program/target/so/program.so
+solana program deploy ./program/target/so/*.so

--- a/tokens/transfer-tokens/pinocchio/package.json
+++ b/tokens/transfer-tokens/pinocchio/package.json
@@ -4,7 +4,7 @@
     "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
     "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
     "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
-    "deploy": "solana program deploy ./program/target/so/program.so"
+    "deploy": "solana program deploy ./program/target/so/*.so"
   },
   "dependencies": {
     "@solana-program/system": "^0.12.2",


### PR DESCRIPTION
## What

The `build`/`deploy` npm scripts and `cicd.sh` in the native and pinocchio examples deploy `program.so`:

```
solana program deploy ./program/target/so/program.so
```

But `cargo build-sbf --sbf-out-dir=./program/target/so` names the output artifact after the **crate**, not `program` — e.g. `token_2022_transfer_fee_pinocchio_program.so`, `transfer_tokens_program.so`. So the documented deploy step fails with "No such file" because `program.so` never exists there.

## Fix

Use a `*.so` glob so the deploy step resolves the built artifact regardless of its crate-derived name:

```
solana program deploy ./program/target/so/*.so
```

Each **single-program** build directory contains exactly one `.so`, so the glob resolves unambiguously. Applied uniformly to both `cicd.sh` and the `deploy` npm script across the affected single-program native and pinocchio examples (75 files).

## Notes

- **CI is unaffected.** These are reference/manual deploy scripts; CI builds to `./tests/fixtures` (via `build-and-test`) and never runs `deploy`. Verified locally that the build emits the crate-named `.so` and the glob resolves to it.

### Excluded

- **The asm example** (`basics/transfer-sol/asm`) uses the `sbpf` toolchain, which has a different output layout and artifact name (its test loads `transfer-sol-cpi.so`); it needs a separate fix.
- **Multi-program examples** (`basics/cross-program-invocation`): the build emits more than one `.so`, so a single `*.so` glob would pass multiple paths to `solana program deploy` (which takes one). Left unchanged — its `cicd.sh` already deploys each program explicitly.

This originated from a review comment on #701, where the same template line was flagged — fixing it repo-wide rather than diverging a single example.