### PR TITLE
docs: add contribution baseline and AI use policy, trim agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,24 @@
 # Agent guide
 
-Solana program examples in three flavors per example: `anchor/`, `native/`, `pinocchio/` (a few have `asm/`). Path convention: `<category>/<example-name>/<framework>`.
+Solana program examples, one per framework flavor (`anchor/`, `native/`, `pinocchio/`, a few `asm/`). Everything below is a decision or trap you cannot see from the files.
 
-## Layout rules
+## Deliberate structure
 
-- **Not a pnpm workspace, on purpose.** Every example has its own `package.json` and `pnpm-lock.yaml` so it can be copied out and run standalone. Never introduce cross-example imports or shared JS helpers. Align dependency versions with `pnpm sync-package-json` from the root.
-- **Rust is one workspace.** Most program crates are members of the root `Cargo.toml`. Crates that can't be members are listed in `.github/.workspace-ignore` (CI enforces one or the other). `tokens/token-2022/transfer-hook/block-list/pinocchio` and `games/world-cup/pinocchio` have their own workspaces.
-- Toolchain pins: `rust-toolchain.toml`, `.nvmrc`, `packageManager` in the root `package.json`, `anchor_version`/`solana_version` in every `Anchor.toml`.
-
-## Build and test
-
-| Framework          | Build + test                                                                                        |
-| ------------------ | --------------------------------------------------------------------------------------------------- |
-| anchor             | `anchor test` in the project (`[scripts] test` in `Anchor.toml` runs mocha)                         |
-| native / pinocchio | `pnpm build-and-test` (cargo build-sbf into `tests/fixtures/`, then `pnpm test`)                    |
-| asm                | same script shape; programs assemble with `sbpf` (rev pinned in `.github/actions/setup/action.yml`) |
-| world-cup          | `just setup && just build && just test` — excluded from the pinocchio workflow by design            |
-
-Rust integration tests live in `program/tests/*.rs` (litesvm) and run with `cargo test --manifest-path=./program/Cargo.toml`; CI runs them only when `program/Cargo.toml` exists.
+- **Not a pnpm workspace, on purpose.** Per-example `package.json` + `pnpm-lock.yaml` so an example can be copied out and run standalone. No cross-example imports, no shared JS helpers. Version alignment is `pnpm sync-package-json` from the root, not hoisting.
+- Rust program crates must be root-workspace members or listed in `.github/.workspace-ignore` (CI enforces one or the other).
+- `.github/.ghaignore` lists CI-skipped projects; every entry needs a comment with the real reason, and reasons rot: verify before trusting one.
+- `games/world-cup` is excluded from the pinocchio workflow by design (own workspace, `just` build).
 
 ## Test stack (do not deviate)
 
-- Runner: **mocha 11 via tsx** (`mocha --import=tsx …`). Never ts-mocha, ts-node, jest, or `node:test` imports — `node:test` suites under mocha exit 0 even when failing.
-- Runtime: **LiteSVM**. Non-anchor tests use `@solana/kit` + `litesvm` 1.x (pattern: `basics/hello-solana/native/tests/index.test.ts`, full version `tokens/create-token/pinocchio/tests/test.ts`). Anchor tests use `@anchor-lang/core` + `anchor-litesvm` + `litesvm` 0.8 with `@solana/web3.js` — deliberate, anchor's JS client is web3.js-based until it moves to kit.
-- litesvm never throws on a failed transaction: assert `result instanceof FailedTransactionMetadata`. Sending the same bytes twice needs `svm.expireBlockhash()` in between.
-- anchor-litesvm pins its own old litesvm; every anchor project carries `pnpm.overrides { "litesvm": "^0.8.0" }`. Without it, failed transactions pass `instanceof` checks silently.
-- Tests must assert real post-state (account bytes, lamport deltas) and fail loudly — verify by breaking an assertion once.
+- Runner is mocha via tsx. Never `node:test` imports: `node:test` suites under mocha exit 0 even when failing.
+- Non-anchor tests: `@solana/kit` + litesvm 1.x. Anchor tests: `@anchor-lang/core` + `anchor-litesvm` + litesvm **0.8** with `@solana/web3.js`: deliberate, anchor's JS client stays web3.js-based until it moves to kit.
+- anchor-litesvm pins its own old litesvm, so every anchor project carries `pnpm.overrides { "litesvm": "^0.8.0" }`. Without it, failed transactions pass `instanceof` checks silently and tests go green.
+- litesvm never throws on a failed transaction: assert `result instanceof FailedTransactionMetadata`. Resending identical bytes needs `svm.expireBlockhash()` in between.
+- bankrun and the older harnesses were removed deliberately; don't reintroduce them from upstream examples or old tutorials.
 
-## Formatting and CI
+## Traps
 
-- TS/MD/JSON: `pnpm format` / `pnpm run check` at the root (prettier, `@solana/prettier-config-solana`). Rust: `cargo fmt` at the root (shared `rustfmt.toml`); clippy runs with `-D warnings` in CI.
-- Workflows discover projects by directory name (`anchor`, `native`, `pinocchio`, `asm`). `.github/.ghaignore` lists CI-skipped projects — every entry needs a comment with the real reason; verify a reason still holds before trusting it.
-- Per-project CI: `pnpm install --frozen-lockfile` (commit lockfiles), `tsc --noEmit` when a `tsconfig.json` exists (keep `skipLibCheck`), build, test.
-
-## Gotchas that have bitten before
-
-- **Resolver-2 feature unification:** a crate must declare every feature-gated dependency it uses itself (e.g. `solana-address` with `curve25519`/`decode`). Whole-workspace builds mask missing features that per-crate CI builds expose.
-- **`anchor keys sync` rewrites `declare_id!` and strips Anchor.toml comments.** Don't run it casually; `basics/cross-program-invocation/anchor` has committed keypairs with a drift guard — never resync it.
-- Fixtures under `tests/fixtures/` are gitignored and built on demand; Metaplex `token_metadata.so` is dumped from mainnet by each project's `prepare.mjs` postinstall. The metadata natives build Metaplex instructions by hand in `mpl_util.rs` — there is no mpl crate dependency; keep it that way.
-- Old runtimes (bankrun) and old harnesses were removed deliberately; don't reintroduce them from upstream examples or old tutorials.
+- **Resolver-2 feature unification:** each crate must declare every feature-gated dependency it uses itself (e.g. `solana-address` with `curve25519`/`decode`). Whole-workspace builds mask what per-crate CI builds expose.
+- **`anchor keys sync` rewrites `declare_id!` and strips Anchor.toml comments.** `basics/cross-program-invocation/anchor` has committed keypairs with a drift guard: never resync it.
+- Metaplex `token_metadata.so` is dumped from mainnet by each project's `prepare.mjs` postinstall. The metadata natives hand-build Metaplex instructions in `mpl_util.rs`, with no mpl crate dependency: keep it that way.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,39 @@
-# Contribution Guidelines
+# Contributing
 
-Thank you for considering contributing to the Solana Program Examples repository. We greatly appreciate your interest and efforts in helping us improve and expand this valuable resource for the Solana developer community.
+Thank you for considering contributing to the Solana Program Examples repository. These examples are a teaching resource: every one of them should be small enough to read in one sitting, runnable standalone, and correct enough that someone can copy it into their own project.
 
 We believe that a welcoming and inclusive environment fosters collaboration and encourages participation from developers of all backgrounds and skill levels.
 
-To ensure a smooth and effective contribution process, please take a moment to review and follow the guidelines outlined below.
+## Before you start
 
-## How to Contribute
+- Search existing issues and pull requests before opening a new one.
+- For substantial changes, such as a new example or a new framework flavor, open an issue or discussion first so maintainers can confirm the approach. Small PRs are preferred.
+- Do not include secrets, private keys, seed phrases, or production credentials in issues, pull requests, commits, logs, or screenshots. Program keypairs belong in gitignored `keys/` directories, never in the diff.
+- All commits into a Solana Foundation repository require [commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) to be enabled. Your PRs will not be merged without this.
 
-We welcome contributions in the form of code, documentation, bug reports, feature requests, and other forms of feedback. Here are some ways you can contribute:
+## Security vulnerabilities
 
-- **Code Contributions:** You can contribute code examples in Rust that demonstrate various Solana program functionalities. You can also contribute improvements to existing examples, such as bug fixes, optimizations, or additional features.
+Do not report security vulnerabilities in public issues. Use [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) on this repository instead.
 
-- **Bug Reports, Ideas or Feedback:** If you encounter any issues or have ideas for new examples, please submit a bug report or feature request. Your feedback is valuable and helps us improve the quality and relevance of the examples.
+Note that the examples here are educational and deliberately minimal. A missing production hardening measure in an example is a normal issue or PR, not a vulnerability report.
+
+## How to contribute
+
+- **Code contributions:** new examples that demonstrate a Solana program pattern, or improvements to existing ones such as bug fixes, optimizations, or additional coverage.
+- **Bug reports, ideas, or feedback:** if an example does not build, is out of date, or is missing, open an issue.
+
+## Development setup
+
+Use the toolchain versions checked into the repository: `rust-toolchain.toml`, `.nvmrc`, `packageManager` in the root `package.json`, and the `anchor_version` / `solana_version` fields in each `Anchor.toml`. Do not bump language runtimes, the Solana CLI, Anchor, or the package manager as an incidental part of another change.
+
+```bash
+pnpm install            # at the root, for formatting tooling
+pnpm format             # prettier write
+pnpm check              # prettier check
+pnpm sync-package-json  # align dependency versions across examples
+```
+
+Per example, run the commands documented in that example's `package.json` or `Anchor.toml`: `anchor test` for Anchor projects, `pnpm build-and-test` for native and Pinocchio projects.
 
 ## General coding and writing guidelines
 
@@ -60,6 +81,63 @@ pnpm format
    When removing or updating an example, please ensure that the example is removed from the `.ghaignore` file
    and there's a change in that example's directory.
 
+## Making a change
+
+Keep changes focused. A pull request should solve one problem and carry the tests, documentation, and generated artifacts needed to keep the repository usable.
+
+Before opening a pull request:
+
+- Format, lint, build, and test the affected examples with the commands above. `cargo fmt` at the root for Rust; clippy runs with `-D warnings` in CI.
+- Add or update tests when behavior changes. Tests must assert real post-state (account data, lamport deltas) and fail loudly: break an assertion once to confirm the test can actually fail.
+- Update the README and any example-level docs when the user-facing contract changes.
+- Regenerate committed derived files (IDLs, generated clients) with the repository's documented tooling, and commit updated lockfiles.
+- Explain any new dependency and why the existing dependency set is insufficient.
+
+Because these are onchain programs, document the account validation, authority checks, state transitions, and value movement your change relies on. Include a threat-model note when the change creates or modifies a trust boundary. An example that teaches an unsafe pattern without flagging it is a bug.
+
+## Pull requests
+
+Write a clear title and description that explain the problem, the approach, and how you tested it. Link related issues and call out behavior changes, compatibility concerns, or follow-up work. Use [Conventional Commits](https://www.conventionalcommits.org/) for commit and PR titles. See [AI use](#ai-use) for how to disclose AI assistance.
+
+By default, [Greptile](https://www.greptile.com) is enabled on all Solana Foundation repositories. Before maintainers review, all Greptile comments must be resolved with either a code fix or an explanation of why no change is needed.
+
+Once CI is approved to run by maintainers, all CI errors must be addressed before the PR will be merged.
+
+Maintainers may ask you to rebase, split a broad change, add tests, or revise documentation before merging.
+
+## AI use
+
+You may use AI-assisted tools, but you should review the generated code, understand its behavior, and run the same checks expected of any other contribution.
+
+If you are building with AI on Solana, check out the [Solana Dev Skill](https://github.com/solana-foundation/solana-dev-skill) or the [Solana MCP](https://mcp.solana.com/) to aid in your work.
+
+Ensure that the generated code adheres to the project's coding standards and best practices. Maintainers can close PRs if they appear to be low-effort AI slop. In particular, audit your changes for the following AI code smells that increase maintenance burden:
+
+- Comments that explain why the _previous_ behavior was wrong and the new behavior is correct. This can be helpful context for reviewers as a GitHub comment in the review, but we do not need a history of every code change living in the codebase.
+- Large blocks of comments with a high density of technical jargon; comments should be distilled to clearly explain _why_ this code is doing something (if it's not obvious), not _what_ (the code should speak for itself).
+- Drive-by refactoring of code that is not relevant to the actual change being made.
+
+Two more that matter specifically here:
+
+- Examples are read as teaching material, so generated code that works but obscures the pattern being taught is worse than none. Prefer the shortest version that shows the mechanism.
+- Do not let a tool spread a change across every framework flavor or every example unless the change genuinely applies to all of them. Bulk edits are hard to review and easy to get subtly wrong per example.
+
+### Disclosure
+
+It can be helpful to note the extent to which AI was used in the change. For example, adding
+
+> I wrote all of the code for this feature, and had Claude update the documentation and create tests accordingly
+
+or
+
+> I architected the change and handed all implementation over to Codex
+
+to the pull request description can be helpful context for reviewers.
+
+### Communication
+
+If maintainers have suggested changes, feedback, or questions about your code, you should not be copy/pasting the questions to an LLM and copy/pasting the response. You being able to distill the information that AI produces is what makes your contribution valuable.
+
 ## Code of Conduct
 
 We are committed to providing a friendly, safe, and welcoming environment for all contributors, regardless of their background, experience level, or personal characteristics. As a contributor, you are expected to:
@@ -69,3 +147,7 @@ Refrain from engaging in any form of harassment, discrimination, or offensive be
 Help create a positive and supportive community where everyone feels valued and respected.
 
 If you encounter any behavior that violates our code of conduct, please report it to the project maintainers immediately.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's [LICENSE](./LICENSE).

--- a/games/gacha/pinocchio/CLAUDE.md
+++ b/games/gacha/pinocchio/CLAUDE.md
@@ -1,198 +1,32 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Provably-fair gacha (loot-box) game: admin configures fixed-weight reward tiers and an entry fee plus an off-chain VRF operator; a buyer commits entropy and pays, the operator reveals an ECVRF `beta`, the program anchors the proof in Collector Crypt's real [`cc-vrf`](https://vrf.collectorcrypt.com) registry by CPI, expands `beta` into a tier, and mints a Token-2022 NFT whose metadata carries a `rarity` field.
 
-## What this is
+Below is only what the code, the `justfile`, and the IDL do not tell you.
 
-A provably-fair **gacha** (loot-box / pack-pull) game on Solana, modeled on how
-platforms like Collector Crypt and Phygitals actually work — and wired into
-Collector Crypt's real [`cc-vrf`](https://vrf.collectorcrypt.com) registry
-program by CPI. An admin configures a pool of fixed-weight reward tiers and a
-fixed entry fee, and registers an off-chain VRF operator. A buyer pays the fee
-to open a pull, committing buyer-supplied entropy into the VRF input. The
-operator reveals the ECVRF output (`beta`); the program anchors the proof in the
-cc-vrf registry, expands `beta` into a weighted tier, and the prize — a
-Token-2022 NFT whose metadata carries a `rarity` field — is minted to the buyer.
+## Randomness model (read before touching anything)
 
-## Randomness model (important)
+RFC 9381 `ECVRF-EDWARDS25519-SHA512-TAI`, following cc-vrf. **Solana cannot verify an ECVRF proof on-chain** (no precompile), so the trust model is _detection, not prevention_: on-chain the program accepts the registered operator's signed `beta`. Each design choice closes a gap detection alone leaves open:
 
-RFC 9381 `ECVRF-EDWARDS25519-SHA512-TAI`, following Collector Crypt's cc-vrf.
-**Solana cannot verify an ECVRF proof on-chain** (no precompile), so the trust
-model is _detection, not prevention_: on-chain the program accepts the
-registered operator's signed `beta`; off-chain anyone can prove cheating. The
-design closes every gap that detection alone leaves open:
+1. **Buyer entropy in alpha.** `alpha = SHA-256(pull_address || client_seed)`, `client_seed` chosen by the buyer at commit. `beta = VRF(operator_key, alpha)` is deterministic, so a merely _fixed_ alpha (the pull address alone) lets the operator precompute every outcome before anyone buys.
+2. **Fixed weights give order-independence.** Tier odds never change after init, so an outcome depends only on its `beta`. Selecting against a mutable remaining-supply table would let an operator who knows every pending `beta` route rare tiers to favored wallets by choosing settle order, and per-pull proof verification would never catch it.
+3. **One reveal per pull, enforced externally.** `settle_pull` CPIs cc-vrf `commit_proof_with_beta`, whose Light Protocol compressed account derives from `(authority, memo_hash = SHA-256(pull_address))`, so a second commit fails at the Light system program. The commit also proves the operator's authority record is frozen, unrevoked, and keyed by exactly `pool.operator`.
+4. **Withholding delays, never steals.** `refund_pull` returns fee + rent after `settle_deadline_slots`, and the vault reserves `pending_pulls × entry_fee` so `withdraw_fees` can never touch pending escrow.
+5. **The operator's 32-byte Ed25519 seed is both its Solana signing key and its ECVRF key**, so `pool.operator` equals the ECVRF public key and the emitted events are enough to reverify a pull off-chain.
 
-1. **Fixed ≠ unpredictable.** `alpha = SHA-256(pull_address || client_seed)`
-   where `client_seed` is 32 random bytes chosen by the buyer at commit. An
-   alpha that is merely _fixed_ (say, the pull address alone) is worthless
-   against the operator: `beta = VRF(operator_key, alpha)` is deterministic, so
-   a predictable alpha lets the operator precompute every outcome before anyone
-   buys. Buyer entropy is what makes the outcome unknowable at commit time.
-2. **Fixed weights ⇒ order-independence.** Tier odds never change after init,
-   so a pull's outcome depends only on its `beta` — not on supply counters or
-   the order in which the operator settles. (Selection against a mutable
-   remaining-supply table would let an operator who knows every pending `beta`
-   route rare tiers to favored wallets purely by choosing settle order, and
-   per-pull proof verification would never catch it.)
-3. **One reveal per pull, enforced by cc-vrf.** `settle_pull` CPIs cc-vrf's
-   `commit_proof_with_beta`, whose Light Protocol compressed account derives
-   from `(authority, memo_hash = SHA-256(pull_address))` — a second commit for
-   the same pull fails at the Light system program. The commit also proves (via
-   validity proof against the registry) that the operator's authority record is
-   **frozen**, unrevoked, and keyed by exactly `pool.operator`.
-4. **Liveness has an escape hatch.** An operator can withhold a reveal (e.g.
-   after privately computing an unfavorable `beta`), but `refund_pull` returns
-   the buyer's entry fee and rent after `settle_deadline_slots`, and
-   `withdraw_fees` can never touch pending buyers' escrow (the vault reserves
-   `pending_pulls × entry_fee`). Withholding delays; it never steals.
-5. **Verification story.** From the emitted events anyone can: recompute
-   `alpha` from `(pull, client_seed)`, verify the proof with
-   `@collectorcrypt/ecvrf`, reproduce the tier with `selectTier`, and check the
-   registry commit. The operator's 32-byte Ed25519 seed is **both** its Solana
-   signing key and its ECVRF key, so `pool.operator` equals the ECVRF public key.
+Oracle VRFs (Switchboard On-Demand, MagicBlock VRF, ORAO) verify on-chain at the cost of fees, latency, and oracle liveness; the cc-vrf pattern trades that for detection-based trust. Trust notes: cc-vrf's upgrade authority was **not** renounced as of 2026-07-29 (contradicting its docs), and its repo declares MIT but commits no LICENSE file.
 
-Comparison: oracle VRFs (Switchboard On-Demand, MagicBlock VRF, ORAO) verify the
-randomness proof **on-chain** at the cost of oracle fees, extra latency, and an
-oracle-network liveness dependency. The cc-vrf pattern is cheaper and
-self-operated, but trust is detection-based. Trust notes: cc-vrf's upgrade
-authority was **not** renounced as of 2026-07-29 (contradicting its docs), and
-its repo declares MIT but commits no LICENSE file.
+## Gotchas
 
-## Required Versions
+- `settle_pull` and `claim_prize` are separate instructions because a settle carries ~10 Light passthrough accounts + a 129-byte validity proof; adding the mint CPI stack blows the 1232-byte transaction limit. (A production client could recombine them with a lookup table.)
+- The 80-byte proof is never stored on-chain: it is hashed into the cc-vrf commit and emitted in `PullSettledEvent`.
+- **Packed state:** never take a reference to a `#[repr(C, packed)]` field whose type has alignment > 1 (u32/u64 arrays); copy into a local first.
+- **Codama limits:** array field types need a **literal** size (`[u32; 8]`, not `[u32; MAX_TIERS]`), and Codama cannot express arrays of custom structs, hence the primitive tier arrays. `just generate-idl && git diff` is the drift check.
+- **Cross-language parity:** `select_tier`/`selectTier` and `derive_alpha`/`pullAlpha` must stay byte-for-byte identical; shared fixtures in both suites pin them.
+- Light Protocol addresses come from `light-sdk-types`. cc-vrf publishes no crate, so its program ID, CPI authority, and instruction discriminator are declared locally in `ccvrf.rs`; foreign CPIs are hand-serialized (Anchor: 8-byte `sha256("global:<name>")` + borsh; SPL interface: 8-byte `SplDiscriminate` + borsh).
+- Integration tests derive PDAs through `gacha_client`'s generated `find_pda` helpers on purpose, so a seed the IDL gets wrong fails the suite instead of shipping. They need `just generate-clients` first.
+- `just light-test` runs single-threaded (shared local gnark prover port, prepared by `just light-bootstrap`, cached in `~/.config/light`) against the mainnet-dumped `tests/fixtures/cc_vrf.so`.
+- `just burst-test <n>` spends devnet SOL: ~0.0025 SOL of pull rent per pull, unrecoverable once a pull is settled (pulls are only closable while pending, via `refund_pull`). `just burst-report` re-scores history for free.
+- When extending: keep `#[codama(...)]` attributes in sync, emit an event per new instruction, add an integration test per instruction.
 
-- **Rust**: See `rust-toolchain.toml`
-- **Node.js**: See `.nvmrc`
-- **pnpm**: See `package.json` `packageManager` field
-- **Light CLI**: pinned in `justfile` (`zk_cli_version`), installed by `just setup`
-
-## Build Commands
-
-```bash
-just build              # program .so → IDL → TS client → dist
-just generate-idl       # Generate IDL via Codama (cargo build with build.rs)
-just generate-clients   # Generate TypeScript + Rust clients from IDL
-just build-program      # Build .so binary only (cargo build-sbf)
-just test               # unit + integration + light + client tests
-just unit-test          # Rust host unit tests (selection + alpha derivation)
-just integration-test   # LiteSVM integration tests (builds the .so first)
-just light-test         # Light-stack tests: real settle -> cc-vrf CPI w/ proofs
-just dump-cc-vrf        # Fetch the mainnet cc-vrf binary for light-test
-just client-test        # TypeScript client tests (parity + ECVRF + forged-reveal)
-just burst-test 200     # Devnet: buy+settle 200 pulls, score the reveals + distribution
-just burst-report       # Re-score every pull the burst pool has recorded (no txs)
-just demo               # Off-chain operator/verifier demo (no RPC)
-just fmt                # cargo fmt + prettier
-just check              # fmt-check + lint-check
-```
-
-## Architecture
-
-Solana program using **Pinocchio** (lightweight `no_std` framework) with **Codama**
-for IDL-driven client generation.
-
-### Client generation pipeline
-
-```
-Rust code with #[codama(...)] attributes
-    ↓
-program/build.rs → idl/gacha.json
-    ↓
-scripts/generate-clients.ts
-    ↓
-clients/{typescript,rust}/src/generated/   (gitignored; re-exported from src/index.ts / lib.rs)
-```
-
-### Program
-
-- `program/src/lib.rs` — declares the program ID, wires modules
-- `program/src/gacha.rs` — pure logic: `select_tier`, `derive_alpha`, prize constants (host unit-tested)
-- `program/src/ccvrf.rs` — hand-built Anchor CPI to cc-vrf `commit_proof_with_beta` (program IDs, wire layout, account order)
-- `program/src/instructions/` — `init_pool`, `buy_pull`, `settle_pull`, `refund_pull`, `withdraw_fees`, `claim_prize`, `emit_event` (self-CPI target) + `helpers/` (`checks`, `account`, `prize_nft` — the Token-2022 NFT mint + metadata CPIs)
-- `program/src/state/` — `Pool`, `Pull` PDA structs + `Vault` / `PrizeMint` markers + `common.rs` (discriminator, pull status, PDA derivation)
-- `program/src/event_engine.rs` — Anchor-compatible self-CPI event emission
-- `program/src/events/` — one event struct per state-changing instruction
-- `program/src/errors.rs` — error codes (100s generic / 200s pool / 300s pull / 400s settle+claim / 500s vault / 600s event)
-- `program/src/tests.rs` — host unit tests for the pure logic
-
-### Accounts
-
-- **Pool** — PDA `["pool", admin]`. One machine per admin: `operator` (+ its cc-vrf
-  `authority_label`), `entry_fee`, `settle_deadline_slots`, `tier_count`, fixed
-  `weights`, monotonic `pulls_count`, and `pending_pulls` (open refund liabilities).
-- **Pull** — PDA `["pull", pool, buyer, index_le]`. One per pull: `client_seed`,
-  `alpha` (= `SHA-256(pull || client_seed)`), `beta` (set on reveal),
-  `tier_selected`, `status` (Pending → Settled → Claimed), `requested_slot`,
-  `settled_slot`. Closed on refund.
-- **Vault** — program-owned, zero-data PDA `["vault", admin]` that escrows entry
-  fees; invariant: balance ≥ rent floor + `pending_pulls × entry_fee`.
-- **PrizeMint** — Token-2022 mint PDA `["mint", pull]`, created at claim:
-  decimals 0, supply 1, mint authority discarded, `MetadataPointer` pointing at
-  itself, `TokenMetadata` with `additional_metadata: [("rarity", <tier label>)]`.
-
-### Lifecycle
-
-`init_pool` (admin sets tiers, fee, deadline, operator + cc-vrf label) →
-`buy_pull` (buyer pays fee + pull rent, supplies `client_seed`, status `Pending`) →
-either `settle_pull` (operator: cc-vrf commit CPI + tier selection, status `Settled`)
-or, past the deadline, `refund_pull` (buyer: fee + rent back, pull closed) →
-`claim_prize` (anyone: mints the prize NFT to the buyer, status `Claimed`).
-`withdraw_fees` (admin) drains settled revenue only. The 80-byte proof is never
-stored on-chain — it is hashed into the cc-vrf commit and emitted in
-`PullSettledEvent` for off-chain verification.
-
-`settle_pull` and `claim_prize` are separate instructions because a settle
-carries ~10 Light passthrough accounts + a 129-byte validity proof, and adding
-the mint CPI stack would exceed the 1232-byte transaction limit. (A production
-client could recombine them with an address lookup table.)
-
-### Testing layers
-
-- `tests/integration-tests` — LiteSVM 0.12: everything that does not need a live
-  cc-vrf (init/buy/refund/withdraw, settle/claim negatives, claim decode via a
-  fabricated settled pull with `set_account`). PDAs are derived through
-  `gacha_client`'s generated `find_pda` helpers, so a seed the IDL gets wrong
-  fails the suite rather than shipping to clients. Requires
-  `just generate-clients` first — hence the recipe dependency.
-- `tests/light-integration-tests` — `light-program-test`: the real
-  `settle_pull` → cc-vrf → Light CPI chain with genuine validity proofs (local
-  gnark prover, prepared by `just light-bootstrap`; binary + keys cached in
-  `~/.config/light`). Runs against the mainnet-dumped `tests/fixtures/cc_vrf.so`.
-  Single-threaded (shared prover port).
-- `scripts/burst-randomness.ts` (`just burst-test <n>`) — devnet statistical test:
-  opens and settles `n` pulls against a throwaway 1-lamport pool owned by
-  `keys/burst-admin-keypair.json`, re-derives every reveal off-chain (alpha, the
-  operator's ECVRF output, the selected tier, proof verification), and scores the
-  tier distribution, beta bit balance, and beta byte uniformity, failing at
-  p < 0.001. `just burst-report` re-scores the pool's whole history without
-  spending anything. Costs ~0.0025 SOL of pull rent per pull, unrecoverable once
-  a pull is settled — pull accounts are only closable while pending, via
-  `refund_pull`.
-
-## Conventions
-
-- **Pinocchio, not Anchor**: use `pinocchio::AccountView`, `Address`, `ProgramResult`.
-- **Packed state**: `#[repr(C, packed)]`, byte-0 discriminator, zero-copy `transmute`.
-  Never take a reference to a packed field whose type has alignment > 1 (u32/u64
-  arrays) — copy the field into a local first.
-- **Light Protocol addresses come from `light-sdk-types`**, not local literals.
-  cc-vrf publishes no crate, so its program ID, CPI authority, and instruction
-  discriminator are still declared in `ccvrf.rs`.
-- **Foreign CPIs are hand-serialized**: Anchor programs (cc-vrf) take an 8-byte
-  `sha256("global:<name>")` discriminator + borsh args; SPL interface programs
-  (token-metadata) take an 8-byte `SplDiscriminate` hash + borsh args. Program
-  IDs and discriminators are constants next to the builder that uses them.
-- **No `mod.rs` business logic**: module declarations and re-exports only.
-- **No code comments** for logic — prefer clear names; use `///` doc comments.
-- **Codama attributes drive IDL**: array field types must use a **literal** size
-  (`[u32; 8]`, not `[u32; MAX_TIERS]`), and Codama cannot express arrays of custom
-  structs — hence primitive tier arrays. `just generate-idl && git diff` catches drift.
-- **Cross-language parity**: `select_tier`/`selectTier` and
-  `derive_alpha`/`pullAlpha` must stay byte-for-byte identical; both pairs are
-  pinned by shared fixtures in their respective test suites.
-
-When extending: keep `#[codama(...)]` attributes in sync, emit an event per new
-instruction, and add an integration test per instruction in `tests/integration-tests/`.
-
-## Program ID
-
-`Bv65bJKK9kwTERuyHdCrXqWf2gKBFwkTx2rnscXaBZsS` (keypair in `keys/`, gitignored)
+Program ID `Bv65bJKK9kwTERuyHdCrXqWf2gKBFwkTx2rnscXaBZsS` (keypair in `keys/`, gitignored).

--- a/games/world-cup/pinocchio/CLAUDE.md
+++ b/games/world-cup/pinocchio/CLAUDE.md
@@ -1,113 +1,20 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+World Cup bracket-prediction game: fixed entry fee, consistency-checked 32-game bracket, admin oracle posts results, permissionless `refresh_score` folds brackets into a global tally, unique winner sweeps the pot. Pinocchio program + Codama-generated TS client + Vite webapp shell.
 
-## What this is
+Below is only what the code and the `justfile` do not tell you.
 
-A World Cup bracket-prediction game on Solana. Entrants pay a fixed fee to submit
-a consistency-checked 32-game bracket; an admin oracle records results; a
-permissionless, idempotent `refresh_score` folds each bracket into a provable
-global tally; the unique winner sweeps the pot. The ranking key is total — score,
-then goal-closeness, then earliest submission — so exactly one winner always exists.
-The on-chain program, the generated client, and the webapp shell are wired together
-end-to-end.
+## Design decisions
 
-## Required Versions
+- **The ranking key is total** (score, then goal-closeness, then earliest submission), so exactly one winner always exists. That is what lets `finalize` prove a winner instead of the program carrying split-pot logic.
+- **Scoring is folded, not iterated.** `refresh_score` is permissionless and idempotent (guarded by each bracket's `tally_mask`), so the tally is provable without a single transaction looping over every bracket.
+- **Oracle results are immutable once set**, and `post_goals` requires all 32 results first. Re-posting a game would retroactively invalidate already-folded brackets.
+- Events are Anchor-compatible self-CPI (`emit_event` signed by the `event_authority` PDA, derived at compile time via `const-crypto`) purely so existing Anchor indexers detect them by the 8-byte event tag.
 
-- **Rust**: See `rust-toolchain.toml`
-- **Node.js**: See `.nvmrc`
-- **pnpm**: See `package.json` `packageManager` field
+## Gotchas
 
-## Build Commands
+- `idl/` is committed; the clients' `generated/` dirs are gitignored and regenerated from it. `just generate-idl && git diff` is the drift check after touching any `#[codama(...)]` attribute.
+- Own Cargo workspace, excluded from the repo's pinocchio CI workflow by design; `just setup && just build && just test` is the only path.
+- When extending: emit an event per new instruction and add an integration test per instruction in `tests/integration-tests/`.
 
-```bash
-just build              # program .so → IDL → TS client → dist
-just generate-idl       # Generate IDL via Codama (cargo build with build.rs)
-just generate-clients   # Generate TypeScript client from IDL
-just build-program      # Build .so binary only (cargo build-sbf)
-just build-client       # Build TypeScript client (tsup)
-just test               # unit + integration tests
-just unit-test          # Rust host unit tests
-just integration-test   # LiteSVM integration tests (builds the .so first)
-just fmt                # cargo fmt + prettier
-just check              # fmt-check + lint-check
-just webapp-dev         # Start the webapp dev server
-```
-
-## Architecture
-
-Solana program using **Pinocchio** (lightweight `no_std` framework) with **Codama**
-for IDL-driven client generation.
-
-### Client generation pipeline
-
-```
-Rust code with #[codama(...)] attributes
-    ↓
-program/build.rs → idl/world_cup.json
-    ↓
-scripts/generate-clients.ts
-    ↓
-clients/typescript/src/generated/   (gitignored; re-exported from src/index.ts)
-```
-
-### Program
-
-- `program/src/lib.rs` — declares the program ID, wires modules
-- `program/src/tournament.rs` — pure logic: bracket tree topology, consistency rules, weighted scoring (host unit-tested)
-- `program/src/instructions/` — `init_config`, `submit_bracket`, `lock`, `post_result`, `post_goals`, `refresh_score`, `finalize`, `claim`, `close_bracket`, `emit_event` (self-CPI target) + `helpers/` (account checks, PDA creation)
-- `program/src/state/` — `Config`, `Oracle`, `Bracket` PDA structs + `Vault` marker + `common.rs` (discriminator, tournament state, PDA derivation)
-- `program/src/event_engine.rs` — Anchor-compatible self-CPI event emission
-- `program/src/events/` — one event struct per state-changing instruction
-- `program/src/errors.rs` — error codes (100s generic / 200s lifecycle / 300s bracket / 400s oracle / 500s finalize+claim / 600s event)
-- `program/src/tests.rs` — host unit tests for pure logic
-
-### Accounts
-
-Global singletons unless noted:
-
-- **Config** — PDA `["config"]`. Admin, lifecycle `state`, `lock_ts`, entry fee, and the provable global tally (`best_score`/`best_closeness`/`best_index`, `entrant_count`, `refreshed_count`, `tally_mask`, `winner`).
-- **Oracle** — PDA `["oracle"]`. Per-game `results[32]` (immutable once set), `decided_mask`, and the Round-of-32 `total_goals_r32`.
-- **Bracket** — PDA `["bracket", owner]`. One per wallet: `picks[32]`, tiebreaker guess, cached score, `tally_mask`, `entry_index` (submission order).
-- **Vault** — program-owned, zero-data PDA `["vault"]` that escrows the pot.
-
-### Events
-
-Events use Anchor-compatible self-CPI: the program invokes its own `emit_event`
-instruction, signed by the `event_authority` PDA (derived at compile time via
-`const-crypto`). Indexers detect the inner instruction by the 8-byte event tag.
-
-### Program ID
-
-`wCupoZtR1g1NXRRVELe5KqFgayyEteVKKxEerxugvxA` (keypair in `keys/`, gitignored)
-
-## Workspace Structure
-
-- `program/` — Pinocchio program (workspace member `world-cup-program`)
-- `tests/integration-tests/` — LiteSVM integration tests (`tests-world-cup`)
-- `clients/typescript/` — Codama-generated TS client (`@solana/world-cup`)
-- `webapp/` — Vite + React Solana app shell
-- `scripts/` — Codama client generation
-- `idl/` — generated IDL, committed (regenerated by `just generate-idl`); the client `generated/` dirs are gitignored and regenerated from it
-
-## Conventions
-
-- **Pinocchio, not Anchor**: use `pinocchio::AccountView`, `Address`, `ProgramResult`.
-- **No `mod.rs` business logic**: module declarations and re-exports only.
-- **No code comments**: prefer clear names and small functions.
-- **PDA seeds co-located with state**: each state struct exposes its seed pattern; derivation helpers live in `state/common.rs`.
-- **Codama attributes drive IDL**: keep `#[codama(...)]` macros in sync with Rust types — `just generate-idl && git diff` catches drift.
-
-## Lifecycle
-
-`init_config` (admin sets `lock_ts`; creates Config + Oracle + vault) → `submit_bracket`
-(entrants pay the fixed fee; rent funds the Bracket, the remainder escrows to the vault)
-→ `lock` (admin, once `Clock >= lock_ts`) → `post_result` ×32 then `post_goals` (admin
-oracle; goals require all results posted) → `refresh_score` ×N (permissionless; folds
-each bracket into the tally once the oracle is complete, idempotent via `tally_mask`) →
-`finalize` (admin proves the unique winner against the total ranking key) → `claim`
-(winner sweeps the vault, repeatable) and `close_bracket` (permissionless; rolls a
-finalized bracket's rent into the pot).
-
-When extending: keep `#[codama(...)]` attributes in sync, emit an event per new
-instruction, and add an integration test per instruction in `tests/integration-tests/`.
+Program ID `wCupoZtR1g1NXRRVELe5KqFgayyEteVKKxEerxugvxA` (keypair in `keys/`, gitignored).


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md`: adopt the shared Foundation contribution structure (before-you-start checklist with signed commits, private vulnerability reporting, development setup, change requirements, PR expectations with Greptile resolution and Conventional Commits, license) on top of the existing repo-specific rules, which are unchanged.
- `CONTRIBUTING.md`: new **AI use** section covering review responsibility, Solana Dev Skill / Solana MCP pointers, the AI code smells maintainers will close PRs over, disclosure, and reviewer communication. Two rules are specific to a teaching repo: generated code that obscures the pattern being taught is worse than none, and do not fan a change across every framework flavor unless it truly applies.
- `AGENTS.md`: cut command tables, toolchain-pin lists, and formatting/CI steps that are all readable from `package.json`, `Anchor.toml`, and the workflows. Kept only the non-obvious parts: why this is not a pnpm workspace, workspace-ignore enforcement, the litesvm `0.8` override silent-pass trap, `node:test`-under-mocha exiting 0, resolver-2 feature unification, and the `anchor keys sync` drift guard. 4.4 KB to 2.3 KB.
- `games/gacha/pinocchio/CLAUDE.md` and `games/world-cup/pinocchio/CLAUDE.md`: same treatment. Dropped `just` command tables, program file trees, account field dumps, and lifecycle walkthroughs; kept the design rationale (gacha's randomness and trust model, world-cup's total ranking key and folded scoring) and the traps (packed-field alignment, Codama literal-array limit, single-threaded light prover, devnet burst cost).

## Test Plan
- Docs only, no code paths touched.
- `pnpm check` (prettier) was not run locally: the root `node_modules` is not installed in this working copy. CI covers it.
