### PR TITLE
feat(token-2022/transfer-hook/allow-block-list-token): add pinocchio example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5918,6 +5918,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "token-2022-abl-token-pinocchio-program"
+version = "0.1.0"
+dependencies = [
+ "pinocchio",
+ "pinocchio-log",
+ "pinocchio-system",
+ "pinocchio-token",
+ "solana-address 2.6.1",
+]
+
+[[package]]
 name = "token-2022-default-account-state-pinocchio-program"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
     "tokens/token-2022/permanent-delegate/pinocchio/program",
     "tokens/token-2022/multiple-extensions/pinocchio/program",
     "tokens/token-2022/immutable-owner/pinocchio/program",
+    "tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Use token account owner data as seeds to derive extra accounts in a transfer hoo
 
 Restrict or allow token transfers using an on-chain allow/block list managed by a list authority.
 
-[anchor](./tokens/token-2022/transfer-hook/allow-block-list-token/anchor)
+[anchor](./tokens/token-2022/transfer-hook/allow-block-list-token/anchor) [pinocchio](./tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio)
 
 ### Transfer hook - block list with Codama clients
 

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/cicd.sh
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/cicd.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This script is for quick building & deploying of the program.
+# It also serves as a reference for the commands used for building & deploying Solana programs.
+# Run this bad boy with "bash cicd.sh" or "./cicd.sh"
+
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
+solana program deploy ./program/target/so/*.so

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/package.json
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/package.json
@@ -1,0 +1,24 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "mocha --import=tsx -t 1000000 ./tests/test.ts",
+    "build-and-test": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./tests/fixtures && pnpm test",
+    "build": "cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so",
+    "deploy": "solana program deploy ./program/target/so/*.so"
+  },
+  "dependencies": {
+    "@solana-program/system": "^0.12.2",
+    "@solana-program/token-2022": "^0.12.0",
+    "@solana/kit": "^7.0.0",
+    "litesvm": "^1.3.0"
+  },
+  "devDependencies": {
+    "@types/chai": "^5.2.3",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^26.1.0",
+    "chai": "^6.2.2",
+    "mocha": "^11.7.5",
+    "typescript": "^5.9.3",
+    "tsx": "^4.19.2"
+  }
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/pnpm-lock.yaml
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/pnpm-lock.yaml
@@ -1,0 +1,2914 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@solana-program/system':
+        specifier: ^0.12.2
+        version: 0.12.2(@solana/kit@7.1.1(typescript@5.9.3))
+      '@solana-program/token-2022':
+        specifier: ^0.12.0
+        version: 0.12.0(@solana/kit@7.1.1(typescript@5.9.3))(@solana/sysvars@8.2.0(typescript@5.9.3))
+      '@solana/kit':
+        specifier: ^7.0.0
+        version: 7.1.1(typescript@5.9.3)
+      litesvm:
+        specifier: ^1.3.0
+        version: 1.4.1(typescript@5.9.3)
+    devDependencies:
+      '@types/chai':
+        specifier: ^5.2.3
+        version: 5.2.3
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
+      '@types/node':
+        specifier: ^26.1.0
+        version: 26.4.0
+      chai:
+        specifier: ^6.2.2
+        version: 6.2.2
+      mocha:
+        specifier: ^11.7.5
+        version: 11.8.0
+      tsx:
+        specifier: ^4.19.2
+        version: 4.23.13
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@solana-program/system@0.12.2':
+    resolution: {integrity: sha512-MaBeOxlvTruQhA7UYkOb3hVTEHPPagOtd+PvTm6a8rGgvEAP0kD4BbC37NceOaR4ABNqdaCmD5OMVRKgrE6KAg==}
+    peerDependencies:
+      '@solana/kit': ^6.4.0
+
+  '@solana-program/system@0.14.0':
+    resolution: {integrity: sha512-Pjs2RINZHYmk/pqWNBCuQmfNjZT9woPJ/w7QkzzCSwcqcokbARtxsnIdgj4lJVxvr1DuxG8JGIbKnq6z1QRY6Q==}
+    peerDependencies:
+      '@solana/kit': ^8.0.0
+
+  '@solana-program/token-2022@0.12.0':
+    resolution: {integrity: sha512-SXkN6Epy9sC3OEELJLhc0hZtUijsAlR2Nb5gP6jcc0WVrtj5wEAmksWxF/yYrAB8AisJVgxvODkhIAnrd02DIw==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@solana/kit': ^6.4.0
+      '@solana/sysvars': ^5.0
+      '@solana/zk-sdk': ^0.4.2
+    peerDependenciesMeta:
+      '@solana/zk-sdk':
+        optional: true
+
+  '@solana-program/token@0.16.0':
+    resolution: {integrity: sha512-VuFIu5vXsw1zwqls4/sGB88234oucmpuig553A33UnrbYnPZ8yXmqLYULBD92/k1pCGnMK+NMLWvsKzlZQ/1Kw==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@solana/kit': ^8.0.0
+
+  '@solana-program/zk-elgamal-proof@0.2.0':
+    resolution: {integrity: sha512-znu1asnySKVp0VyOlfXCLZhpdWvyq/tJ7GRrX61Z6vyXXqJ/OMizv2BkgYL/VbzDKkFmUiYfiFwF3gDtZHv7VA==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+
+  '@solana/accounts@7.1.1':
+    resolution: {integrity: sha512-7sy9VIFMdmu/7+2kVBRMU6mEvYx/DDjfam8DsBXbh+JszaTNZH3V8FutQYHRxrca3jxiumVfsy5USwKfVg8ElQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/accounts@8.2.0':
+    resolution: {integrity: sha512-An3BICrQJQ7jR5EIgXzYnaKyCE7+ZusW9xX8m6Vj7U2cKo8t6Y3PTQ+aMjEajwzsQfxEL8QnpClFC9hdoIu7MA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/addresses@7.1.1':
+    resolution: {integrity: sha512-/Tk2aTOT7UEcaJrdEcB3+SK09v5cZ/92NWqHBzEobxusTPNoeOFxa3MwV74Q1MgPecWdLz7TPreEhAKpcvV/vw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/addresses@8.2.0':
+    resolution: {integrity: sha512-7Okh8u7d3QrKu7ltJa3PASniUhasn1cdbcMQ/8gpGsmHQNCvdtAmvw18xSTdr4m62RJ/0cI/DtTVQyNwooeAXQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/assertions@7.1.1':
+    resolution: {integrity: sha512-tD07UKuw5i9Tw5xloVH+TUMrLzbHKixaB4DlGXumMEQU+JbYRPtFNqtMlrpVLuVM45nkbPfFp2Da0sXNRIqFHA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/assertions@8.2.0':
+    resolution: {integrity: sha512-izrnF8ZsviZDK0WCKl9ha5Ht4TNDHoU2QzMrPYOqkSkKkVh15p3MjTRXVFnM4CA+Xigtu8y8OPu2UnQNcAUVHQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-core@7.1.1':
+    resolution: {integrity: sha512-C1UOAQ7LH8RuCTfaij6hthTZeBlpp8GuD2g9Nag/xgiNKJGvAfVrcorb+kO/sufdYI8Lu+BiVvPeKOjQDQiKqg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-core@8.2.0':
+    resolution: {integrity: sha512-ORwzswFXbqNqlyVigogFIrn3Ge5cpDQkuMY0u3M40HBwHcC6a79uqM87DpoZypncKJDWA1DfJ/3w9hhTGumYAw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-data-structures@7.1.1':
+    resolution: {integrity: sha512-MO+wMAuaatAQ96N3HhTsd7Uno+79rJw88P+OiU2n+pHK/rZuyu1yB2j12veqK4jUNWPR0aOyCuZ4rB2idrDjpg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-data-structures@8.2.0':
+    resolution: {integrity: sha512-uq59oSAXM9QR+cO7R3JmSTxBiNNJnayVWz2VHBdhhCQS8DEmd6hhqY1RVmPTpFtE0Jix5MkRV3Bu5GTmf6Y66A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-numbers@7.1.1':
+    resolution: {integrity: sha512-TWWrQq6Wp5Yf5bSc6RbxDDYCRUBBmRtRgjvUMHGp0P9K+4uFwxllRjSZFzBPHgXj3UTeZmFJdcoD271QhAgibg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-numbers@8.2.0':
+    resolution: {integrity: sha512-GTOYzyk0SxQJS7MAN9zsyax4RFUtQDYzkVcpRf0Zo7eOy2/hPfuih09VJL2YdLPBJBcg8satdAYBYxxC282PYQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-strings@7.1.1':
+    resolution: {integrity: sha512-6qWl+atG60D2LmP47GyGapQFhVsG1sVhVrEaM3lV09vwrGOMeOZARZ4ObaQ5m6uQmM04G+f8dY9d17nCMbGHGg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
+      typescript:
+        optional: true
+
+  '@solana/codecs-strings@8.2.0':
+    resolution: {integrity: sha512-Dt/+rJ6gmH/OcOtvrhm6CtbB9jtVOGMxcIXoi62eNXw39Z1kJyN1gkqTjzBSS8Xb+X5lfkL70GHE9EDBb1JmqA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
+      typescript:
+        optional: true
+
+  '@solana/codecs@7.1.1':
+    resolution: {integrity: sha512-1ZErMXzbbz7+jusem58dMO1haVWNlvFYKftc2dPhFu9MqlmZRfPS06GiZDjlLnD/6PHHBy7OKFMASoYw+fBAKg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs@8.2.0':
+    resolution: {integrity: sha512-kn2esyzFznx6Pbb+8FUe3YNKYRZUB8H81pCiXSIe1+0WJ44lRhZHMo0s4L3FQMKhWHOnlV30sWeIg8taHLVW7g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/errors@7.1.1':
+    resolution: {integrity: sha512-q35qck8rBnNvJlPU00mnHEQm7gWvghzYz8khqVoLhjgodTzGp46VqnIOyI1LXOAF6XDal58bMNDO980MQgq8yw==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/errors@8.2.0':
+    resolution: {integrity: sha512-BXc9mafl3SOnRL542jY02ezBSXHgqQOUCzREN/vvh1ASUPrUB3iorOEc62cSxFdDU4aDVMcugowJawmVNTXXSg==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/fast-stable-stringify@7.1.1':
+    resolution: {integrity: sha512-eVxOeAXYVBIWOIRfGwvuGQ6gPetQiiiOqSCK0xjwQo/yjXNVlSbpF6wLtQRnd3lbYkWsKdeV99FYe9cVY/g7/Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/fast-stable-stringify@8.2.0':
+    resolution: {integrity: sha512-OND76Qsng/fiTVSUvaNZFv0WKEULlwcGRtgeIE2keA2xYoHYNTSoD6mxv4iWANfeDo4EH7D/HnOwnGEFXMjr9w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/fixed-points@7.1.1':
+    resolution: {integrity: sha512-qPj/V7kcFG/P0kuEa1U529+5L6mbkMwRIwvYBTDgBqPOt6wOdk9/c7Qn2VUQgSV0HgCXWxdHUdwaxBrYqO2ibg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/fixed-points@8.2.0':
+    resolution: {integrity: sha512-w19JKErcbbENZzw4B+oBGwJXVKMIOi8TC7WxBawmpuv0XJSk6LP6surosg+XeoBHhtEsVCNHDtizi0mAS6OmMw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/functional@7.1.1':
+    resolution: {integrity: sha512-AnFohvUHGrqAu3kTxxC0rZyU4JddA08hOUZ1/DT9XogCZWetBpNJktX9uNuXQe+sN4FKTX2MfL//iBFBAsxtDA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/functional@8.2.0':
+    resolution: {integrity: sha512-+oTPl9yRZBbppUZU8qs4eu93iWPvs4Ij+HELPHISxLFo/cuG2YZGTDcWBVEzc8XEw0DUwwBOvou/wP7v1SnH+A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instruction-plans@7.1.1':
+    resolution: {integrity: sha512-KQGpsjeDflMcbKCdcF4KZVHcotYMS94DveRs0ZiBOsxb45dgkYrFmQ6ExJ/2exUOVF/rlp73knAP5ACrPMIAzA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instruction-plans@8.2.0':
+    resolution: {integrity: sha512-DDVHBAPifG3Q0s5e2hiBbfvrruLb3AhumTupDK+3f3f7MDc0Dth6rX054HtIINloqbFIw15f6/A3Z4VTh74CTg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instructions@7.1.1':
+    resolution: {integrity: sha512-VxMpJI++RTwaqSBLIP1GTjOPLtlYOqxOJ93ug6DlSdu9jku8M/or77DiXDUi62VmEh3bbsECR646vTJXUaPArw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instructions@8.2.0':
+    resolution: {integrity: sha512-SFts84wW6hDXGSrLK5spl8nbKxKns2aR+S2ar0Zi3I0bl007heyoO7UKyxAoUvhfhObIfEIMuy2/qLoo6vDcjQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/keys@7.1.1':
+    resolution: {integrity: sha512-Rx+vzWAXUa/Ko7W6wG1HOG9B3nQFZ5dALz113WoAmBZf7iQvaLG7U4ECDM/ydR+Nbdy6wYww7zQKRIye+1d+Nw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/keys@8.2.0':
+    resolution: {integrity: sha512-DezFZ0/ya98nILq+eSeq9fu9onVfqQYb7mtuDctdWxY1QFJvix562zkkFuFqnjOLL7XMEpdVPMxxQOzZ33wGCg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/kit@7.1.1':
+    resolution: {integrity: sha512-By3kv5d8fIMr2SPmvI41hBXUwn0XuDu2MC8B7anaLHtY8MENTKhjg8sSfybf/RTH3387ErxhxmrAijTiHqTy/g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/kit@8.2.0':
+    resolution: {integrity: sha512-1BfmnYmWe17u3RRX3HuNxjWkr2/n9Bai+yIG/XjMpgviobF3n8zsisZBJHPH2uORqvjkTFnOqGXoEQC8vUZHzw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/nominal-types@7.1.1':
+    resolution: {integrity: sha512-do4rmmOlSplVYN92zV6nROJxkiRn0c7juoH1lka2Pmq+cAC3QhQXKYAwWffTFYDJJDO9qCOh00uv2hhSZi6RDw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/nominal-types@8.2.0':
+    resolution: {integrity: sha512-iuDE6ewgT7LJOSVC6UK4HR6n8INujujbglYVVFWNK/xWKi5p1y8JCOEEWAl/htK26LhLC51A1nMNfmBmTjP3ZQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/offchain-messages@7.1.1':
+    resolution: {integrity: sha512-Py0/8HaIF0y+KSXHAWdQYDdZlGNoaqOZonTFuGKyDsrkgvod3wRc0cpZ5I/D/Rei4tVpvjNUfCXLpyoiJAZ7kg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/offchain-messages@8.2.0':
+    resolution: {integrity: sha512-yXfVtK1VoQ/Eyz2jH/1+avixhYcpCPkGkXuiXxA3Vf73WCvniC8mNVQ5ppsV+OqCNw62mxaFMmNiVgiAQapKuw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/options@7.1.1':
+    resolution: {integrity: sha512-iuPpfMbnRFjC4IoAIpKNA9UpizomxjW0E3F1LxUYQHXm1vCoF78kThp4qqgx2V3DmDFbhXGtXGSJPwmDdpLoBg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/options@8.2.0':
+    resolution: {integrity: sha512-b3//UzZe/uBaIpw4fT/nvCOghh5IHoNkW7FCMA/nzvQ48A16n8qpLki9/+lLHi0V0o7/Jz5Sof0UYc0aSf1Dig==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/plugin-core@7.1.1':
+    resolution: {integrity: sha512-35h7+QssfnT9Rwq5spUvdGc41WtTVWzJUCbiwvnUHtVwm3z96xSPwj765UtX/enfrcRHJRTDvej2ZjsvO1aeuQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/plugin-core@8.2.0':
+    resolution: {integrity: sha512-V7oSIhYXbUzjd5LUY4tbSUnyBka1hmULPFKuqxNzYxeY4eLI7S8GmTOg7xg6tOC0bJ+HLPvv64asuMXAn/PklQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/plugin-interfaces@7.1.1':
+    resolution: {integrity: sha512-2SHkGiftGmxg5xA5esxbwiY5wf+BOUsJG5rxD64/SHadUMaN3L0SDUSJfAXETJq5dCmVWxWGGPf2yVox4RIfdA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/plugin-interfaces@8.2.0':
+    resolution: {integrity: sha512-goOhGI493Fq+xhZ8JKl9/FDVFd0SJdkv5Lh0L2ubqekzUiGRCvHNwgXL8nVS7fso2UxIssDQmYKwXvubfhBVhw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/program-client-core@7.1.1':
+    resolution: {integrity: sha512-zoMq8Qg6psj6tFYpA35xKhSrF/LpdiVflV6nKohxZg3ocwtRqRhQfbY8/mjCA9EfH8vqvsn5il5CnxALRqmJJA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/program-client-core@8.2.0':
+    resolution: {integrity: sha512-miQ7qKW0d0etaa2YAehGU3heV5Y4ip5BBCwZXb/yg8yWndTt4d4E+8z+5Q/oS5kOuFraOFYr+Uev7SQKngNXBg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/programs@7.1.1':
+    resolution: {integrity: sha512-nWpJKDBxj+cRpzH+lzdp+ztEm6MAothts56s7PIPFIKJe3zGRUpske0G3jIVHOGvtzCgQtmZUMCS1uBRiDRKDQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/programs@8.2.0':
+    resolution: {integrity: sha512-yttl6ps7G9vM83pdfekyregTIqmRThFpdcrCIZ3y2qOLZ63KVxVMhNJ8kn8FrX3MyWh5rr/hTWdWKc4/U12Epg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/promises@7.1.1':
+    resolution: {integrity: sha512-d3lhCfiFwiVyTRR6zhy1lcjDIh+l0a5gp1WPe64Vfa2gP0myC8P5C1Tknfjrp4d97DF3uBPqKAb5vV8hahNcNA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/promises@8.2.0':
+    resolution: {integrity: sha512-i33ll+en6/Qcjw10gPeikCmU687W1pQNZPxirEuRWO/+PhE2qDQ9ZODgEakVi/1k+vSwL8sK941qfWig+3D0dQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-api@7.1.1':
+    resolution: {integrity: sha512-ELGIqNbz8apeAxCLdD1PEPAnu6KtgHmWvUbH4VqqNg2jgWquyUOfTI5rblvdflx2Hcb7GK05w8/iiUaknOQKnw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-api@8.2.0':
+    resolution: {integrity: sha512-lGvk1xeOo4cbypuD/5AAkJPHv5E3g7lqbzRIxZhsQPBkK+knVuEb7e3UncOnjuWkijZoFiB/k+Rfk83gmlhdpg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-parsed-types@7.1.1':
+    resolution: {integrity: sha512-DiQSj2rNnhOKOTs6YDjQ2y4KuOkv8lh6moLFiQnY0+TvanJrGrQjxLSrHdCUQxymQcUxzrraZL9k6vxNzId4gw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-parsed-types@8.2.0':
+    resolution: {integrity: sha512-JJ4BfUlX8eCIUh3zm8jTkHkNLf6HyY9UjJmi4GPicFPJZ5MXSUeh42eaSxvHszXUoS7u9V30kTt1hznwfF5fqA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec-types@7.1.1':
+    resolution: {integrity: sha512-FDDgXfAPfq28sQNnGhZr/+2kp5QTTcNZ5m/Q9y9Jrlux6brdPsbf9Sh1Q/lgz7i76arzNW/rzRY125RzqGWANg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec-types@8.2.0':
+    resolution: {integrity: sha512-pKOezoP0vuVwyjUKcS4Ewl3Mm/owv/16n7RocqFC3nx94qtk5FpSOAtielUHzBQ3JUgRLJrSKonw2yWxqgtVFg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec@7.1.1':
+    resolution: {integrity: sha512-1FwhgL18qasRYlWffdBNIUoxQyGLzdh3YMQW3y33M61vk/q1ldEGJRypV9B/SrXmxwqDiUbQ+m+zgainCTp1ZA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec@8.2.0':
+    resolution: {integrity: sha512-fR0hv/NP3K4WNePK9+97GYrDjzoN7kF0hlffRlSygksAC0FKvtKQ5lPBMg0ptWtswInp8Kk7Cz1zTCf6S+wLUQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-api@7.1.1':
+    resolution: {integrity: sha512-QTiQHmw2I/+fzeYsqII1guASiZskS7KZwPCI+6Arfk6Hxo9hBH8APuIu6uS8beSlVfnBCoOMybVDsnPF88fAoQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-api@8.2.0':
+    resolution: {integrity: sha512-37UHtjFmBUagtRw9NeWViTqSJlExyuI2j88m3jJSw9c6WRw7lLzUJIRGA51ArYyhAyhtAoGjXpUZiODKSE9lEw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-channel-websocket@7.1.1':
+    resolution: {integrity: sha512-DRakQwjJsvbLDMDafMC9hM82YotUwSnrzqUDsrm6+e4YpKvzjXCyWlQ9kDJtrYeAA15sNVRpfs4L9Y7SoiWgrw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-channel-websocket@8.2.0':
+    resolution: {integrity: sha512-R9pk8Lq030M1+bAz6e2qKv6ldGLmICFYJOaLxVifyDE4VBb1BGV3Tt1VTAaFIfHyYucmFmxGRmPFmedA3Kysqw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-spec@7.1.1':
+    resolution: {integrity: sha512-yrqd+fV2Ae4hkzXX42aKRmTrz3FwvzKqO4h0ahs88dzSvXpy8l6Svu1k+uRgMlZ64g2P83jfQW+3Pj5fBoxmdw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-spec@8.2.0':
+    resolution: {integrity: sha512-ajcncAnQ7XzE85MZ8uajjO9E7NyLwLWFVUYG+y82vb04ZWFRN3DrMswIC4T5m14OkU3RY/Z2WGxC9nT1W4wPWw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions@7.1.1':
+    resolution: {integrity: sha512-5BaCgzPnf9WSEXBdASnM7iuPWtdrXKtG16qVTfm+9icLHDAkv2y62XF6XMSQQllH2k1RvLH1yOryZazAbaIyHA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions@8.2.0':
+    resolution: {integrity: sha512-pHf/RiDqIHeGp2blseYRVjzWz4WUAY/5vkOya+BQhjx+7Odr/J19G3ZVDwExgtU95UhCDL9gVHPyAgKr0mNcUg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transformers@7.1.1':
+    resolution: {integrity: sha512-k8a/JZFso/nvPBgurOGJ/ZC6sXCtYE3lCvTj95i29pl45C4SgjdetJrAH/pWEEhQXcxaJs7OLBGmCh2enazlJw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transformers@8.2.0':
+    resolution: {integrity: sha512-tiMdJ9ZRgqANBNxlXK7OSDbwixAy7K1MzowzO7vNdlJbV+0WN0Lm/X5hEhKnlU42AD+clC6t9qZjVbg7BhQrqw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transport-http@7.1.1':
+    resolution: {integrity: sha512-Tljuh/sSkKMHrTqdYNaguUOkZ0T+Oj4+yHsUjKAzRsyffNLa67jx9gd5CtGfz3tpBpxDLVdNvdIaZgkhFwXk9g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transport-http@8.2.0':
+    resolution: {integrity: sha512-eOkgv52ZSMFLYNQaCsvxmPciZeXplWaPjbEcl9iZkGOAp3B2bO6KyMg8trEjaZNfcLC15+CpXMOZpMArXXSBCg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-types@7.1.1':
+    resolution: {integrity: sha512-yHlSUWgynaaqevuqipGhhcZnmFVNs+F6KIlbUZ0kQY6NMVtaSzx5AQrtQjbtAQzNRsRTDYkKuQg8nOruiDoseQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-types@8.2.0':
+    resolution: {integrity: sha512-rGF2vB8Bk0G2DYNxgEbDlANk+KirQGHVS1qRLxsi6OxACrgsSrGqrp0Onb5J8HLRMTEF+QrbbORDz9TQ5Q71fQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc@7.1.1':
+    resolution: {integrity: sha512-yXEzCrLrWb1m5QqAJEGodJ9cqu5QiwfirSZTUWiMg1JtUl4uXOm1sqWQVLrwBz/+ctvtZTvG8+bQQAemVQiqPA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc@8.2.0':
+    resolution: {integrity: sha512-Of/2KqDf728HxKzJlwlZRvRSrgpHoDAg5+t/3RwdXWBoRQ1r3FXqwBXOrBT2g47w+fUy1iJcy5XZ7LXnXBXPIg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/signers@7.1.1':
+    resolution: {integrity: sha512-UfWYnAglm21q5hS3Op1bU5mYiWfx0VesovZcIur0uYPc3EJlfBVikl8pf745x+bB77xG6lIzNbb+99t48SQbkg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/signers@8.2.0':
+    resolution: {integrity: sha512-wfLiDhtPMnE9Mn8IeSAJ0RMfCyHUqeNZllFLfgDY3RUsCf5s9EgMC5U+HNSvtEWJ8ABGWWR5nYyWMXTWiMeuPA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/subscribable@7.1.1':
+    resolution: {integrity: sha512-l4Wzc2L+7WQPeC/kaCiia1aaUY/SJJdrNHnLibKchS2pb7YbF7J2OygsweHXliWCVpG0jZwcvIVpusgygbZQLw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/subscribable@8.2.0':
+    resolution: {integrity: sha512-ATJBeJkaCUIxU3JWUcgfOjnOM3nn9qDfTigEkr0Cp3xFzIHnIVwis3W4Hcc/de1z0uvOXQOIYroahDr8H+djOg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/sysvars@7.1.1':
+    resolution: {integrity: sha512-EscE/HKbBRKedG6AtQ0t9LOX87bw409viferac5YSuvuDxtZvbMpCCJs89uEQPVpgvHtjMJhfsjEwMK97uG9pA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/sysvars@8.2.0':
+    resolution: {integrity: sha512-kwhOwBfUvUGuGGGnwTGHtNVQ02O3YCfXpp4xwUhe6bjUyp9M9wEmf70up6I9x2D4uB1nHaZRfco1CXfxhcH8sg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-confirmation@7.1.1':
+    resolution: {integrity: sha512-Kb3V5smmMbvdft/Z/Iu9MlsF+i44f3GLK8c8TVu0+yHo41rF7OeTnOvlQ+uw1NpCfOto4GgPMFDXklIiKdauuA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-confirmation@8.2.0':
+    resolution: {integrity: sha512-3L1LlMQ00l2kb3pcejvQ7vMKzyFayFhc6PqvZyh3M0/FNPfsc4z46yUf35I79SI6cuFWy2VkzA+a2ylOuCNC7w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-introspection@7.1.1':
+    resolution: {integrity: sha512-o0f/wbwmgqRSqzr+RtCG8xZ5zTMVxnYv8LBmcDDCYvTeDPEF0EfHN8Oe28c7grQsXCIeaE+zXZ2p40lkTGZy4g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-introspection@8.2.0':
+    resolution: {integrity: sha512-unha6ugKrZa1TcB5Slnxisa/uQC56fyYi7BDvfCVI60OLEowtOTTvmJMKe35ETMzbimjBEPE/B5EgbydOHVBnQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-messages@7.1.1':
+    resolution: {integrity: sha512-UBgd/TU0c8blrYDC9sD9P+wgmOOEK4OdODxD8CxB7oumN4ZAENv20u0AdZuvu1n4OwWwc1ikhtKjwg18e4wTIg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-messages@8.2.0':
+    resolution: {integrity: sha512-+0U4iR/WRb8UiBXRhJJUY0+BmAOv+bQj7fifUF6o7x/IPg/K2Y4CmH4m7dOT2yhcg0KDzZPkXidXLm6saBX0Hw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transactions@7.1.1':
+    resolution: {integrity: sha512-jop8y4+xiDJlocRLxqN++33Z5PDTe72HwmtgGrcIuGB4zq7U/lUX0uZM1JVcs9d3lJ3wBy2CcLTCyoYb78Swhg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transactions@8.2.0':
+    resolution: {integrity: sha512-WfbzFTf2BvpW14OIOin/9Mj29XE5GJVORAnziDK+GEiTPnruNzNkHBrd2kt/ACg12dh12kmutDj5WI3pzrN3Bw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/mocha@10.0.10':
+    resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
+
+  '@types/node@26.4.0':
+    resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+
+  browser-stdout@1.3.1:
+    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decamelize@4.0.0:
+    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
+    engines: {node: '>=10'}
+
+  diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+    engines: {node: '>=0.3.1'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
+    hasBin: true
+
+  litesvm-darwin-arm64@1.4.1:
+    resolution: {integrity: sha512-6dofWLOxtknSL0W6N9W3f/kdnitsJ3xR0oE1W37CLcfd5kX4qCMVbaejZWJkLo4G2JzAk+hFZi965Z2OPyJACg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  litesvm-darwin-x64@1.4.1:
+    resolution: {integrity: sha512-Rjyg6SfnSKAO5/vMpnZpIHTcBWEUzjFj/GshXwzdyiWorrpC0poQjK3OJ9RJneJW2YDd+oUsGZCfwAplTXPGfg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  litesvm-linux-arm64-gnu@1.4.1:
+    resolution: {integrity: sha512-hyL/tcuFisAwNEwVzDGjtDRuLYDc+8PoX9QZU/M46vsLrdU2WCBU3g4WdV5z0z1nPl16TzcHVboqydyBy3ImFQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  litesvm-linux-arm64-musl@1.4.1:
+    resolution: {integrity: sha512-Folc4nWAXwkWvwK5iqf3C74eNAPRERg8Yn2QGVW+6pMgCXtaQt77PuIB9m32mLo+W+LZxiU+t3et0ZiFEm4YgQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  litesvm-linux-x64-gnu@1.4.1:
+    resolution: {integrity: sha512-sAKax22lAMS0DpWQcT6ICt8vs6phEjRJXT84LhhftnlNkcU03b0RJziFDr34LUTrkY5SMi/uqZEy0T86Xokg+w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  litesvm-linux-x64-musl@1.4.1:
+    resolution: {integrity: sha512-kKsOVhF7o8/sMiP6mgZCoIYr7zWEzwOBQdC0WrWp29JvOJpKOOgz3jioFdgWv/LnSYfkbJ+wZNWI8tMhAkmNOw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  litesvm@1.4.1:
+    resolution: {integrity: sha512-SGMdN6c44m5Deo27nZX7GIn42e/OlfQ4jIv0JIVxR3F5vU8ZbbjsLRGUj3b/r5jCITyN22u14JnuP+mhDyNLlg==}
+    engines: {node: '>= 20'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mocha@11.8.0:
+    resolution: {integrity: sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  tsx@4.23.13:
+    resolution: {integrity: sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@8.10.0:
+    resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  workerpool@9.3.4:
+    resolution: {integrity: sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs-unparser@2.0.0:
+    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
+    engines: {node: '>=10'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@solana-program/system@0.12.2(@solana/kit@7.1.1(typescript@5.9.3))':
+    dependencies:
+      '@solana/kit': 7.1.1(typescript@5.9.3)
+
+  '@solana-program/system@0.14.0(@solana/kit@8.2.0(typescript@5.9.3))':
+    dependencies:
+      '@solana/kit': 8.2.0(typescript@5.9.3)
+
+  '@solana-program/token-2022@0.12.0(@solana/kit@7.1.1(typescript@5.9.3))(@solana/sysvars@8.2.0(typescript@5.9.3))':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@solana-program/zk-elgamal-proof': 0.2.0(@solana/kit@7.1.1(typescript@5.9.3))
+      '@solana/kit': 7.1.1(typescript@5.9.3)
+      '@solana/sysvars': 8.2.0(typescript@5.9.3)
+
+  '@solana-program/token@0.16.0(@solana/kit@8.2.0(typescript@5.9.3))':
+    dependencies:
+      '@solana-program/system': 0.14.0(@solana/kit@8.2.0(typescript@5.9.3))
+      '@solana/kit': 8.2.0(typescript@5.9.3)
+
+  '@solana-program/zk-elgamal-proof@0.2.0(@solana/kit@7.1.1(typescript@5.9.3))':
+    dependencies:
+      '@solana-program/system': 0.12.2(@solana/kit@7.1.1(typescript@5.9.3))
+      '@solana/kit': 7.1.1(typescript@5.9.3)
+
+  '@solana/accounts@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/accounts@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/addresses@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/addresses@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/nominal-types': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/assertions@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/assertions@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-core@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-core@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-data-structures@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-data-structures@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/fixed-points': 7.1.1(typescript@5.9.3)
+      '@solana/options': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/codecs@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/fixed-points': 8.2.0(typescript@5.9.3)
+      '@solana/options': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/errors@7.1.1(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 15.0.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/errors@8.2.0(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 15.0.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/fast-stable-stringify@7.1.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/fast-stable-stringify@8.2.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/fixed-points@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/fixed-points@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/functional@7.1.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/functional@8.2.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/instruction-plans@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/instruction-plans@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/instructions': 8.2.0(typescript@5.9.3)
+      '@solana/keys': 8.2.0(typescript@5.9.3)
+      '@solana/promises': 8.2.0(typescript@5.9.3)
+      '@solana/transaction-messages': 8.2.0(typescript@5.9.3)
+      '@solana/transactions': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/instructions@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/instructions@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/keys@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/keys@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/nominal-types': 8.2.0(typescript@5.9.3)
+      '@solana/promises': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/kit@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 7.1.1(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/instruction-plans': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/offchain-messages': 7.1.1(typescript@5.9.3)
+      '@solana/plugin-core': 7.1.1(typescript@5.9.3)
+      '@solana/plugin-interfaces': 7.1.1(typescript@5.9.3)
+      '@solana/program-client-core': 7.1.1(typescript@5.9.3)
+      '@solana/programs': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+      '@solana/rpc': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-api': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/signers': 7.1.1(typescript@5.9.3)
+      '@solana/subscribable': 7.1.1(typescript@5.9.3)
+      '@solana/sysvars': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-confirmation': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-introspection': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/kit@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 8.2.0(typescript@5.9.3)
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/functional': 8.2.0(typescript@5.9.3)
+      '@solana/instruction-plans': 8.2.0(typescript@5.9.3)
+      '@solana/instructions': 8.2.0(typescript@5.9.3)
+      '@solana/keys': 8.2.0(typescript@5.9.3)
+      '@solana/offchain-messages': 8.2.0(typescript@5.9.3)
+      '@solana/plugin-core': 8.2.0(typescript@5.9.3)
+      '@solana/plugin-interfaces': 8.2.0(typescript@5.9.3)
+      '@solana/program-client-core': 8.2.0(typescript@5.9.3)
+      '@solana/programs': 8.2.0(typescript@5.9.3)
+      '@solana/promises': 8.2.0(typescript@5.9.3)
+      '@solana/rpc': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-api': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+      '@solana/signers': 8.2.0(typescript@5.9.3)
+      '@solana/subscribable': 8.2.0(typescript@5.9.3)
+      '@solana/sysvars': 8.2.0(typescript@5.9.3)
+      '@solana/transaction-confirmation': 8.2.0(typescript@5.9.3)
+      '@solana/transaction-introspection': 8.2.0(typescript@5.9.3)
+      '@solana/transaction-messages': 8.2.0(typescript@5.9.3)
+      '@solana/transactions': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/nominal-types@7.1.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/nominal-types@8.2.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/offchain-messages@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/offchain-messages@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/keys': 8.2.0(typescript@5.9.3)
+      '@solana/nominal-types': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/plugin-core@7.1.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/plugin-core@8.2.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/plugin-interfaces@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 7.1.1(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/instruction-plans': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/signers': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/plugin-interfaces@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 8.2.0(typescript@5.9.3)
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/instruction-plans': 8.2.0(typescript@5.9.3)
+      '@solana/keys': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+      '@solana/signers': 8.2.0(typescript@5.9.3)
+      '@solana/transactions': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/program-client-core@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 7.1.1(typescript@5.9.3)
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/instruction-plans': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/plugin-interfaces': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-api': 7.1.1(typescript@5.9.3)
+      '@solana/signers': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/program-client-core@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 8.2.0(typescript@5.9.3)
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/instruction-plans': 8.2.0(typescript@5.9.3)
+      '@solana/instructions': 8.2.0(typescript@5.9.3)
+      '@solana/plugin-interfaces': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-api': 8.2.0(typescript@5.9.3)
+      '@solana/signers': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/programs@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/programs@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/promises@7.1.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/promises@8.2.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-api@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-api@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/keys': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+      '@solana/transaction-messages': 8.2.0(typescript@5.9.3)
+      '@solana/transactions': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-parsed-types@7.1.1(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-parsed-types@8.2.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-spec-types@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-spec-types@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-spec@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/subscribable': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-spec@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 8.2.0(typescript@5.9.3)
+      '@solana/subscribable': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-subscriptions-api@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-api@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/keys': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+      '@solana/transaction-messages': 8.2.0(typescript@5.9.3)
+      '@solana/transactions': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 7.1.1(typescript@5.9.3)
+      '@solana/subscribable': 7.1.1(typescript@5.9.3)
+      ws: 8.21.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@solana/rpc-subscriptions-channel-websocket@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/functional': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 8.2.0(typescript@5.9.3)
+      '@solana/subscribable': 8.2.0(typescript@5.9.3)
+      ws: 8.21.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@solana/rpc-subscriptions-spec@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/subscribable': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-subscriptions-spec@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/promises': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 8.2.0(typescript@5.9.3)
+      '@solana/subscribable': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-subscriptions@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/subscribable': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/rpc-subscriptions@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 8.2.0(typescript@5.9.3)
+      '@solana/functional': 8.2.0(typescript@5.9.3)
+      '@solana/promises': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+      '@solana/subscribable': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/rpc-transformers@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-transformers@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/functional': 8.2.0(typescript@5.9.3)
+      '@solana/nominal-types': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-transport-http@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      undici-types: 8.10.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-transport-http@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 8.2.0(typescript@5.9.3)
+      undici-types: 8.10.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-types@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/fixed-points': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-types@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/fixed-points': 8.2.0(typescript@5.9.3)
+      '@solana/nominal-types': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-api': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-transport-http': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 8.2.0(typescript@5.9.3)
+      '@solana/functional': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-api': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-transport-http': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/offchain-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/instructions': 8.2.0(typescript@5.9.3)
+      '@solana/keys': 8.2.0(typescript@5.9.3)
+      '@solana/nominal-types': 8.2.0(typescript@5.9.3)
+      '@solana/offchain-messages': 8.2.0(typescript@5.9.3)
+      '@solana/transaction-messages': 8.2.0(typescript@5.9.3)
+      '@solana/transactions': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/subscribable@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/subscribable@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/promises': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/sysvars@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/sysvars@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-confirmation@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/promises': 7.1.1(typescript@5.9.3)
+      '@solana/rpc': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/transaction-confirmation@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/keys': 8.2.0(typescript@5.9.3)
+      '@solana/promises': 8.2.0(typescript@5.9.3)
+      '@solana/rpc': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+      '@solana/transaction-messages': 8.2.0(typescript@5.9.3)
+      '@solana/transactions': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/transaction-introspection@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+      '@solana/transactions': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-introspection@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/instructions': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+      '@solana/transaction-messages': 8.2.0(typescript@5.9.3)
+      '@solana/transactions': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-messages@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-messages@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/functional': 8.2.0(typescript@5.9.3)
+      '@solana/instructions': 8.2.0(typescript@5.9.3)
+      '@solana/nominal-types': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@7.1.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
+      '@solana/functional': 7.1.1(typescript@5.9.3)
+      '@solana/instructions': 7.1.1(typescript@5.9.3)
+      '@solana/keys': 7.1.1(typescript@5.9.3)
+      '@solana/nominal-types': 7.1.1(typescript@5.9.3)
+      '@solana/rpc-types': 7.1.1(typescript@5.9.3)
+      '@solana/transaction-messages': 7.1.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@8.2.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 8.2.0(typescript@5.9.3)
+      '@solana/codecs-strings': 8.2.0(typescript@5.9.3)
+      '@solana/errors': 8.2.0(typescript@5.9.3)
+      '@solana/functional': 8.2.0(typescript@5.9.3)
+      '@solana/instructions': 8.2.0(typescript@5.9.3)
+      '@solana/keys': 8.2.0(typescript@5.9.3)
+      '@solana/nominal-types': 8.2.0(typescript@5.9.3)
+      '@solana/rpc-types': 8.2.0(typescript@5.9.3)
+      '@solana/transaction-messages': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/mocha@10.0.10': {}
+
+  '@types/node@26.4.0':
+    dependencies:
+      undici-types: 8.3.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.3.0: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
+
+  browser-stdout@1.3.1: {}
+
+  camelcase@6.3.0: {}
+
+  chai@6.2.2: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@15.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3(supports-color@8.1.1):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
+
+  decamelize@4.0.0: {}
+
+  diff@7.0.0: {}
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat@5.0.2: {}
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-caller-file@2.0.5: {}
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  has-flag@4.0.0: {}
+
+  he@1.2.0: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-path-inside@3.0.3: {}
+
+  is-plain-obj@2.1.0: {}
+
+  is-unicode-supported@0.1.0: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-yaml@4.3.2:
+    dependencies:
+      argparse: 2.0.1
+
+  litesvm-darwin-arm64@1.4.1:
+    optional: true
+
+  litesvm-darwin-x64@1.4.1:
+    optional: true
+
+  litesvm-linux-arm64-gnu@1.4.1:
+    optional: true
+
+  litesvm-linux-arm64-musl@1.4.1:
+    optional: true
+
+  litesvm-linux-x64-gnu@1.4.1:
+    optional: true
+
+  litesvm-linux-x64-musl@1.4.1:
+    optional: true
+
+  litesvm@1.4.1(typescript@5.9.3):
+    dependencies:
+      '@solana-program/system': 0.14.0(@solana/kit@8.2.0(typescript@5.9.3))
+      '@solana-program/token': 0.16.0(@solana/kit@8.2.0(typescript@5.9.3))
+      '@solana/kit': 8.2.0(typescript@5.9.3)
+    optionalDependencies:
+      litesvm-darwin-arm64: 1.4.1
+      litesvm-darwin-x64: 1.4.1
+      litesvm-linux-arm64-gnu: 1.4.1
+      litesvm-linux-arm64-musl: 1.4.1
+      litesvm-linux-x64-gnu: 1.4.1
+      litesvm-linux-x64-musl: 1.4.1
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
+  lru-cache@10.4.3: {}
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
+  minipass@7.1.3: {}
+
+  mocha@11.8.0:
+    dependencies:
+      browser-stdout: 1.3.1
+      chokidar: 4.0.3
+      debug: 4.4.3(supports-color@8.1.1)
+      diff: 7.0.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 10.5.0
+      he: 1.2.0
+      is-path-inside: 3.0.3
+      js-yaml: 4.3.2
+      log-symbols: 4.1.0
+      minimatch: 9.0.9
+      ms: 2.1.3
+      picocolors: 1.1.1
+      serialize-javascript: 6.0.2
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      workerpool: 9.3.4
+      yargs: 17.7.3
+      yargs-parser: 21.1.1
+      yargs-unparser: 2.0.0
+
+  ms@2.1.3: {}
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  package-json-from-dist@1.0.1: {}
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  picocolors@1.1.1: {}
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  readdirp@4.1.2: {}
+
+  require-directory@2.1.1: {}
+
+  safe-buffer@5.2.1: {}
+
+  serialize-javascript@6.0.2:
+    dependencies:
+      randombytes: 2.1.0
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  tsx@4.23.13:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@8.10.0: {}
+
+  undici-types@8.3.0: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  workerpool@9.3.4: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  ws@8.21.3: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs-unparser@2.0.0:
+    dependencies:
+      camelcase: 6.3.0
+      decamelize: 4.0.0
+      flat: 5.0.2
+      is-plain-obj: 2.1.0
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/Cargo.toml
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "token-2022-abl-token-pinocchio-program"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pinocchio.workspace = true
+solana-address.workspace = true
+pinocchio-log.workspace = true
+pinocchio-system.workspace = true
+pinocchio-token.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+custom-heap = []
+custom-panic = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/decide.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/decide.rs
@@ -1,0 +1,109 @@
+//! The transfer decision, kept as a pure function of the decoded mint and
+//! wallet state so it can be unit-tested without building real accounts.
+
+use crate::error::AblError;
+
+/// What the mint's metadata says.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MintMode {
+    Allow,
+    Block,
+    Threshold(u64),
+}
+
+/// What a wallet's record says, if it has one.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum WalletMode {
+    Allow,
+    Block,
+    None,
+}
+
+/// Decides whether a transfer may proceed.
+///
+/// A wallet with an explicit `allowed: false` record is blocked from
+/// transacting entirely — neither sending nor receiving — whatever the mint's
+/// mode. That is checked first and applies to both sides.
+///
+/// Beyond that, `Allow` and `Threshold` gate who may *receive* only, matching
+/// the documented semantics of the Anchor version: `Allow` requires the
+/// receiver to be on the list; `Threshold` requires it for transfers at or
+/// above the threshold.
+pub fn decide(mint_mode: MintMode, source: WalletMode, destination: WalletMode, amount: u64) -> Result<(), AblError> {
+    if source == WalletMode::Block || destination == WalletMode::Block {
+        return Err(AblError::WalletBlocked);
+    }
+
+    match (mint_mode, destination) {
+        (MintMode::Allow, WalletMode::Allow) => Ok(()),
+        (MintMode::Allow, _) => Err(AblError::WalletNotAllowed),
+        // Neither wallet was explicitly blocked, checked above.
+        (MintMode::Block, _) => Ok(()),
+        (MintMode::Threshold(threshold), WalletMode::None) if amount >= threshold => Err(AblError::AmountNotAllowed),
+        (MintMode::Threshold(_), _) => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINT_MODES: [MintMode; 3] = [MintMode::Allow, MintMode::Block, MintMode::Threshold(100)];
+    const WALLET_MODES: [WalletMode; 3] = [WalletMode::Allow, WalletMode::Block, WalletMode::None];
+
+    #[test]
+    fn a_blocked_source_is_always_rejected() {
+        for mint_mode in MINT_MODES {
+            for destination in WALLET_MODES {
+                assert!(
+                    decide(mint_mode, WalletMode::Block, destination, 0).is_err(),
+                    "a blocked source must be rejected for {mint_mode:?} / {destination:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_blocked_destination_is_always_rejected() {
+        for mint_mode in MINT_MODES {
+            for source in WALLET_MODES {
+                assert!(
+                    decide(mint_mode, source, WalletMode::Block, 0).is_err(),
+                    "a blocked destination must be rejected for {mint_mode:?} / {source:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn allow_mode_does_not_gate_the_source() {
+        // Only "who may receive" is restricted; this is the control case
+        // proving the block check above does not over-reach.
+        assert!(decide(MintMode::Allow, WalletMode::None, WalletMode::Allow, 0).is_ok());
+    }
+
+    #[test]
+    fn allow_mode_rejects_an_unlisted_destination() {
+        assert!(decide(MintMode::Allow, WalletMode::None, WalletMode::None, 0).is_err());
+    }
+
+    #[test]
+    fn block_mode_allows_unlisted_wallets() {
+        assert!(decide(MintMode::Block, WalletMode::None, WalletMode::None, 0).is_ok());
+    }
+
+    #[test]
+    fn threshold_mode_allows_small_transfers_to_unlisted_destinations() {
+        assert!(decide(MintMode::Threshold(100), WalletMode::None, WalletMode::None, 50).is_ok());
+    }
+
+    #[test]
+    fn threshold_mode_rejects_transfers_at_the_threshold() {
+        assert!(decide(MintMode::Threshold(100), WalletMode::None, WalletMode::None, 100).is_err());
+    }
+
+    #[test]
+    fn threshold_mode_allows_large_transfers_to_an_allowed_destination() {
+        assert!(decide(MintMode::Threshold(100), WalletMode::None, WalletMode::Allow, 100).is_ok());
+    }
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/error.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/error.rs
@@ -1,0 +1,35 @@
+use pinocchio::error::ProgramError;
+
+/// Errors returned by this example, surfaced as `ProgramError::Custom`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AblError {
+    /// One of the wallets in the transfer is explicitly blocked.
+    WalletBlocked = 0,
+    /// The mint is in `Allow` mode and the receiver is not on the list.
+    WalletNotAllowed = 1,
+    /// The transfer is at or above the mixed-mode threshold and the receiver is
+    /// not on the list.
+    AmountNotAllowed = 2,
+    /// The mint's metadata does not parse, or holds an unknown mode.
+    InvalidMetadata = 3,
+    /// The mode byte in the instruction data is not 0, 1 or 2.
+    InvalidMode = 4,
+    /// The mint does not name this program as its transfer hook.
+    MintNotUsingThisHook = 5,
+    /// An account is not the PDA this program derives for it.
+    InvalidSeeds = 6,
+    /// An account is not owned by this program, or is the wrong size.
+    InvalidAccountData = 7,
+    /// The signer is not the config's authority.
+    NotAuthority = 8,
+    /// The source account is not a Token-2022 account belonging to the mint.
+    InvalidSourceAccount = 9,
+    /// The hook was invoked while the source account was not mid-transfer.
+    IsNotCurrentlyTransferring = 10,
+}
+
+impl From<AblError> for ProgramError {
+    fn from(error: AblError) -> Self {
+        ProgramError::Custom(error as u32)
+    }
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/config.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/config.rs
@@ -1,0 +1,129 @@
+use pinocchio::{cpi::Seed, error::ProgramError, AccountView, Address, ProgramResult};
+use pinocchio_log::log;
+
+use crate::{
+    error::AblError,
+    instructions::expect_pda,
+    state::{
+        read_config_authority, write_config, write_wallet, AB_WALLET_SEED, AB_WALLET_SIZE, CONFIG_SEED, CONFIG_SIZE,
+    },
+    util::create_pda_account,
+};
+
+/// Creates the program config, recording who may edit the allow/block list.
+///
+/// Whoever calls this first becomes the authority, matching the Anchor version.
+///
+/// Accounts:
+///   0. `[signer, writable]` payer (becomes the authority)
+///   1. `[writable]`         config (PDA `[b"config"]`)
+///   2. `[]`                 system program
+///
+/// Instruction data: none beyond the discriminator.
+pub fn init_config(program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
+    let [payer, config, _system_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !payer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    let bump = expect_pda(program_id, config, &[CONFIG_SEED])?;
+    let bump_bytes = [bump];
+    let seeds = [Seed::from(CONFIG_SEED), Seed::from(&bump_bytes)];
+
+    log!("Creating config");
+    create_pda_account(payer, config, CONFIG_SIZE, program_id, &seeds)?;
+    write_config(&mut config.try_borrow_mut()?, payer.address(), bump)?;
+
+    log!("Config created");
+    Ok(())
+}
+
+/// Fails unless `config` is this program's config and names `authority`.
+///
+/// This is Anchor's `seeds` + `has_one = authority` on the config account.
+fn check_authority(program_id: &Address, config: &AccountView, authority: &AccountView) -> ProgramResult {
+    if !authority.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    expect_pda(program_id, config, &[CONFIG_SEED])?;
+    if !config.owned_by(program_id) {
+        return Err(AblError::InvalidAccountData.into());
+    }
+    if read_config_authority(&config.try_borrow()?)? != authority.address().as_ref() {
+        return Err(AblError::NotAuthority.into());
+    }
+    Ok(())
+}
+
+/// Adds a wallet to the allow or block list.
+///
+/// Accounts:
+///   0. `[signer, writable]` authority
+///   1. `[]`                 config (PDA `[b"config"]`)
+///   2. `[]`                 wallet being listed
+///   3. `[writable]`         ab_wallet (PDA `[b"ab_wallet", wallet]`)
+///   4. `[]`                 system program
+///
+/// Instruction data: `[allowed: u8]` — non-zero allows, zero blocks.
+pub fn init_wallet(program_id: &Address, accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
+    let [authority, config, wallet, ab_wallet, _system_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    check_authority(program_id, config, authority)?;
+
+    let allowed = *data.first().ok_or(ProgramError::InvalidInstructionData)? != 0;
+
+    let bump = expect_pda(program_id, ab_wallet, &[AB_WALLET_SEED, wallet.address().as_ref()])?;
+    let bump_bytes = [bump];
+    let seeds = [Seed::from(AB_WALLET_SEED), Seed::from(wallet.address().as_ref()), Seed::from(&bump_bytes)];
+
+    log!("Listing wallet");
+    create_pda_account(authority, ab_wallet, AB_WALLET_SIZE, program_id, &seeds)?;
+    write_wallet(&mut ab_wallet.try_borrow_mut()?, wallet.address(), allowed)?;
+
+    log!("Wallet listed");
+    Ok(())
+}
+
+/// Removes a wallet's record, returning its rent to the authority.
+///
+/// A wallet with no record is neither allowed nor blocked, so this restores it
+/// to whatever the mint's mode says about unlisted wallets.
+///
+/// Accounts:
+///   0. `[signer, writable]` authority (receives the rent)
+///   1. `[]`                 config (PDA `[b"config"]`)
+///   2. `[]`                 wallet being delisted
+///   3. `[writable]`         ab_wallet (PDA `[b"ab_wallet", wallet]`)
+///   4. `[]`                 system program
+///
+/// Instruction data: none beyond the discriminator.
+pub fn remove_wallet(program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
+    let [authority, config, wallet, ab_wallet, _system_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    check_authority(program_id, config, authority)?;
+    expect_pda(program_id, ab_wallet, &[AB_WALLET_SEED, wallet.address().as_ref()])?;
+
+    if !ab_wallet.owned_by(program_id) || ab_wallet.data_len() != AB_WALLET_SIZE {
+        return Err(AblError::InvalidAccountData.into());
+    }
+
+    log!("Delisting wallet");
+
+    // The rent goes back to the authority, matching Anchor's `close = authority`.
+    // It has to move *before* `close`, which zeroes the lamports field outright
+    // — closing first would destroy them and unbalance the instruction.
+    let reclaimed = ab_wallet.lamports();
+    ab_wallet.set_lamports(0);
+    authority.set_lamports(authority.lamports().checked_add(reclaimed).ok_or(AblError::InvalidAccountData)?);
+    ab_wallet.close()?;
+
+    log!("Wallet delisted");
+    Ok(())
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/mint.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/mint.rs
@@ -217,6 +217,13 @@ pub fn init_mint(program_id: &Address, accounts: &mut [AccountView], data: &[u8]
 /// Only the mint's transfer-hook authority can do this — Token-2022 enforces
 /// that on the update below, so no check here would add anything.
 ///
+/// The mint must already carry a readable `AB` policy. Attaching without one
+/// would activate the hook over metadata `Execute` cannot read, and since
+/// `ChangeMode` can only update metadata that already exists, a mint with no
+/// `TokenMetadata` at all could never be recovered — every transfer of it would
+/// fail permanently. Refusing up front makes that unreachable; set the mode
+/// with `ChangeMode` first, then attach.
+///
 /// Accounts:
 ///   0. `[signer, writable]` payer (must be the mint's transfer-hook authority)
 ///   1. `[writable]`         mint
@@ -235,6 +242,13 @@ pub fn attach_to_mint(program_id: &Address, accounts: &mut [AccountView]) -> Pro
     }
     if !mint.owned_by(&TOKEN_2022_PROGRAM_ID) {
         return Err(AblError::InvalidAccountData.into());
+    }
+
+    {
+        let mint_data = mint.try_borrow()?;
+        let metadata = read_ab_metadata(&mint_data, [MODE_KEY, THRESHOLD_KEY])?;
+        let mode = metadata.mode.ok_or(AblError::InvalidMetadata)?;
+        Mode::from_metadata_value(&mode)?;
     }
 
     log!("Pointing the mint at this hook");

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/mint.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/mint.rs
@@ -1,0 +1,348 @@
+use alloc::vec::Vec;
+
+use pinocchio::{
+    cpi::{invoke, Seed},
+    error::ProgramError,
+    instruction::{InstructionAccount, InstructionView},
+    sysvars::{rent::Rent, Sysvar},
+    AccountView, Address, ProgramResult, Resize,
+};
+use pinocchio_log::log;
+use pinocchio_system::instructions::{CreateAccount, Transfer};
+
+use crate::{
+    error::AblError,
+    instructions::{expect_pda, EXTRA_ACCOUNT_METAS_DATA, TOKEN_2022_PROGRAM_ID},
+    metadata::{decimal_to_u64, metadata_initialize, metadata_update_field, read_ab_metadata, u64_to_decimal},
+    state::{Mode, META_LIST_SEED, MODE_KEY, THRESHOLD_KEY},
+    token2022::{get_extension_data, TRANSFER_HOOK},
+    util::create_pda_account,
+};
+
+/// Token-2022 instruction discriminators built by hand here.
+const INITIALIZE_MINT_2: u8 = 20;
+const INITIALIZE_PERMANENT_DELEGATE: u8 = 35;
+const TRANSFER_HOOK_EXTENSION: u8 = 36;
+const METADATA_POINTER_EXTENSION: u8 = 39;
+
+/// Sub-discriminators of the two extension instructions.
+const EXTENSION_INITIALIZE: u8 = 0;
+const EXTENSION_UPDATE: u8 = 1;
+
+/// Size of a mint carrying `PermanentDelegate`, `TransferHook` and
+/// `MetadataPointer`:
+///
+/// ```text
+///   base mint (82), padded to Account::LEN (165) + account-type byte (1) = 166
+///   PermanentDelegate  type (2) + length (2) + value (32) =  36
+///   TransferHook       type (2) + length (2) + value (64) =  68
+///   MetadataPointer    type (2) + length (2) + value (64) =  68
+/// ```
+///
+/// The variable-length `TokenMetadata` written afterwards grows the account,
+/// which is why both this instruction and `change_mode` top the rent up.
+const MINT_SIZE: usize = 338;
+
+fn extension_data(discriminator: u8, sub: u8, authority: &Address, target: &Address) -> Vec<u8> {
+    let mut data = Vec::with_capacity(66);
+    data.push(discriminator);
+    data.push(sub);
+    data.extend_from_slice(authority.as_ref());
+    data.extend_from_slice(target.as_ref());
+    data
+}
+
+fn invoke_on_mint(mint: &AccountView, data: &[u8]) -> ProgramResult {
+    let accounts = [InstructionAccount::writable(mint.address())];
+    invoke(&InstructionView { program_id: &TOKEN_2022_PROGRAM_ID, accounts: &accounts, data }, &[*mint])
+}
+
+/// Tops the account up to rent exemption for its current size.
+///
+/// Writing metadata reallocates the mint, so it can fall below the minimum.
+fn top_up_rent(payer: &AccountView, account: &AccountView) -> ProgramResult {
+    let required = Rent::get()?.try_minimum_balance(account.data_len())?;
+    let current = account.lamports();
+    if required > current {
+        Transfer { from: payer, to: account, lamports: required - current }.invoke()?;
+    }
+    Ok(())
+}
+
+/// Writes the mode (and threshold, in mixed mode) into the mint's metadata.
+fn write_mode(
+    token_program: &AccountView,
+    mint: &AccountView,
+    authority: &AccountView,
+    mode: Mode,
+    threshold: u64,
+    force_threshold: bool,
+) -> ProgramResult {
+    metadata_update_field(token_program.address(), mint, authority, MODE_KEY, mode.as_str().as_bytes())?;
+
+    // Token-2022 cannot remove a metadata key, only overwrite it, so leaving
+    // mixed mode zeroes the threshold rather than deleting it — the same
+    // compromise the Anchor version makes.
+    if mode == Mode::Mixed || force_threshold {
+        let value = if mode == Mode::Mixed { threshold } else { 0 };
+        metadata_update_field(token_program.address(), mint, authority, THRESHOLD_KEY, &u64_to_decimal(value))?;
+    }
+
+    Ok(())
+}
+
+/// Writes the extra-account-metas list for `mint`.
+fn write_meta_list(
+    program_id: &Address,
+    payer: &AccountView,
+    mint: &AccountView,
+    meta_list: &mut AccountView,
+) -> ProgramResult {
+    let bump = expect_pda(program_id, meta_list, &[META_LIST_SEED, mint.address().as_ref()])?;
+    let bump_bytes = [bump];
+    let seeds = [Seed::from(META_LIST_SEED), Seed::from(mint.address().as_ref()), Seed::from(&bump_bytes)];
+
+    create_pda_account(payer, meta_list, EXTRA_ACCOUNT_METAS_DATA.len(), program_id, &seeds)?;
+    meta_list.try_borrow_mut()?.copy_from_slice(&EXTRA_ACCOUNT_METAS_DATA);
+    Ok(())
+}
+
+/// Creates a mint that is gated by this hook from the moment it exists.
+///
+/// Extensions must all be initialized before the mint itself: once
+/// `InitializeMint2` runs, Token-2022 refuses further extension setup.
+///
+/// Accounts:
+///   0. `[signer, writable]` payer (mint and metadata update authority)
+///   1. `[signer, writable]` mint (a fresh keypair)
+///   2. `[writable]`         extra account meta list (PDA `[b"extra-account-metas", mint]`)
+///   3. `[]`                 system program
+///   4. `[]`                 Token-2022 program
+///
+/// Instruction data:
+/// `[decimals: u8, mode: u8, threshold: u64 (LE),
+///   permanent_delegate: [u8; 32], transfer_hook_authority: [u8; 32],
+///   name_len: u8, name, symbol_len: u8, symbol, uri_len: u8, uri]`
+pub fn init_mint(program_id: &Address, accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
+    let [payer, mint, meta_list, system_program, token_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !payer.is_signer() || !mint.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    let decimals = *data.first().ok_or(ProgramError::InvalidInstructionData)?;
+    let mode = Mode::from_byte(*data.get(1).ok_or(ProgramError::InvalidInstructionData)?)?;
+    let threshold = u64::from_le_bytes(
+        data.get(2..10)
+            .ok_or(ProgramError::InvalidInstructionData)?
+            .try_into()
+            .map_err(|_| ProgramError::InvalidInstructionData)?,
+    );
+    let permanent_delegate: &[u8; 32] = data
+        .get(10..42)
+        .ok_or(ProgramError::InvalidInstructionData)?
+        .try_into()
+        .map_err(|_| ProgramError::InvalidInstructionData)?;
+    let hook_authority: &[u8; 32] = data
+        .get(42..74)
+        .ok_or(ProgramError::InvalidInstructionData)?
+        .try_into()
+        .map_err(|_| ProgramError::InvalidInstructionData)?;
+
+    let mut offset = 74usize;
+    let mut strings: [&[u8]; 3] = [&[], &[], &[]];
+    for slot in strings.iter_mut() {
+        let len = *data.get(offset).ok_or(ProgramError::InvalidInstructionData)? as usize;
+        let start = offset + 1;
+        *slot = data.get(start..start + len).ok_or(ProgramError::InvalidInstructionData)?;
+        offset = start + len;
+    }
+    let [name, symbol, uri] = strings;
+
+    let rent = Rent::get()?;
+
+    log!("Creating mint");
+    CreateAccount {
+        from: payer,
+        to: mint,
+        lamports: rent.try_minimum_balance(MINT_SIZE)?,
+        space: MINT_SIZE as u64,
+        owner: &TOKEN_2022_PROGRAM_ID,
+    }
+    .invoke()?;
+
+    // A permanent delegate can move this token from any account, which is what
+    // makes an enforced allow/block list meaningful for a regulated asset.
+    let mut delegate_data = Vec::with_capacity(33);
+    delegate_data.push(INITIALIZE_PERMANENT_DELEGATE);
+    delegate_data.extend_from_slice(permanent_delegate);
+    invoke_on_mint(mint, &delegate_data)?;
+
+    invoke_on_mint(
+        mint,
+        &extension_data(TRANSFER_HOOK_EXTENSION, EXTENSION_INITIALIZE, &Address::from(*hook_authority), program_id),
+    )?;
+
+    // The metadata pointer names the mint itself, so the metadata lives in the
+    // mint account rather than a separate one.
+    invoke_on_mint(
+        mint,
+        &extension_data(METADATA_POINTER_EXTENSION, EXTENSION_INITIALIZE, payer.address(), mint.address()),
+    )?;
+
+    let mut mint_data = Vec::with_capacity(35);
+    mint_data.push(INITIALIZE_MINT_2);
+    mint_data.push(decimals);
+    mint_data.extend_from_slice(payer.address().as_ref());
+    mint_data.push(0); // freeze_authority: COption::None
+    invoke_on_mint(mint, &mint_data)?;
+
+    log!("Writing metadata");
+    metadata_initialize(token_program.address(), mint, payer, mint, payer, name, symbol, uri)?;
+    write_mode(token_program, mint, payer, mode, threshold, false)?;
+    top_up_rent(payer, mint)?;
+
+    log!("Writing meta list");
+    write_meta_list(program_id, payer, mint, meta_list)?;
+
+    let _ = system_program;
+    log!("Mint created");
+    Ok(())
+}
+
+/// Points an existing mint at this hook and gives it a metas list.
+///
+/// Only the mint's transfer-hook authority can do this — Token-2022 enforces
+/// that on the update below, so no check here would add anything.
+///
+/// Accounts:
+///   0. `[signer, writable]` payer (must be the mint's transfer-hook authority)
+///   1. `[writable]`         mint
+///   2. `[writable]`         extra account meta list (PDA `[b"extra-account-metas", mint]`)
+///   3. `[]`                 system program
+///   4. `[]`                 Token-2022 program
+///
+/// Instruction data: none beyond the discriminator.
+pub fn attach_to_mint(program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
+    let [payer, mint, meta_list, _system_program, _token_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !payer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    if !mint.owned_by(&TOKEN_2022_PROGRAM_ID) {
+        return Err(AblError::InvalidAccountData.into());
+    }
+
+    log!("Pointing the mint at this hook");
+    let mut data = Vec::with_capacity(34);
+    data.push(TRANSFER_HOOK_EXTENSION);
+    data.push(EXTENSION_UPDATE);
+    data.extend_from_slice(program_id.as_ref());
+    let accounts_meta =
+        [InstructionAccount::writable(mint.address()), InstructionAccount::readonly_signer(payer.address())];
+    invoke(
+        &InstructionView { program_id: &TOKEN_2022_PROGRAM_ID, accounts: &accounts_meta, data: &data },
+        &[*mint, *payer],
+    )?;
+
+    write_meta_list(program_id, payer, mint, meta_list)?;
+
+    log!("Attached");
+    Ok(())
+}
+
+/// Changes a mint's allow/block mode.
+///
+/// Token-2022 enforces that the signer is the metadata update authority, which
+/// is the only permission this needs — the Anchor version relies on the same
+/// thing and carries no config check either.
+///
+/// Accounts:
+///   0. `[signer, writable]` authority (the metadata update authority)
+///   1. `[writable]`         mint
+///   2. `[]`                 Token-2022 program
+///   3. `[]`                 system program
+///
+/// Instruction data: `[mode: u8, threshold: u64 (LE)]`
+pub fn change_mode(_program_id: &Address, accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
+    let [authority, mint, token_program, _system_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !authority.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    if !mint.owned_by(&TOKEN_2022_PROGRAM_ID) {
+        return Err(AblError::InvalidAccountData.into());
+    }
+
+    let mode = Mode::from_byte(*data.first().ok_or(ProgramError::InvalidInstructionData)?)?;
+    let threshold = u64::from_le_bytes(
+        data.get(1..9)
+            .ok_or(ProgramError::InvalidInstructionData)?
+            .try_into()
+            .map_err(|_| ProgramError::InvalidInstructionData)?,
+    );
+
+    // If the mint already carries a threshold it has to be rewritten even when
+    // leaving mixed mode, otherwise a stale value would keep gating transfers.
+    let has_threshold = {
+        let mint_data = mint.try_borrow()?;
+        read_ab_metadata(&mint_data, [MODE_KEY, THRESHOLD_KEY])
+            .map(|metadata| metadata.threshold.is_some_and(|value| decimal_to_u64(&value).unwrap_or(0) > 0))
+            .unwrap_or(false)
+    };
+
+    write_mode(token_program, mint, authority, mode, threshold, has_threshold)?;
+    top_up_rent(authority, mint)?;
+
+    log!("Mode changed");
+    Ok(())
+}
+
+/// Rewrites an existing mint's metas list to the current layout.
+///
+/// Permissionless on purpose: the content is fully determined by the mint and
+/// this program's own fixed list, so gating it on the transfer-hook authority
+/// would strand mints whose authority has been revoked.
+///
+/// Accounts:
+///   0. `[signer, writable]` payer
+///   1. `[]`                 mint
+///   2. `[writable]`         extra account meta list (PDA `[b"extra-account-metas", mint]`)
+///   3. `[]`                 system program
+///
+/// Instruction data: none beyond the discriminator.
+pub fn resize_meta_list(program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
+    let [payer, mint, meta_list, _system_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !payer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    expect_pda(program_id, meta_list, &[META_LIST_SEED, mint.address().as_ref()])?;
+
+    // Only rewrite lists belonging to mints that actually use this hook.
+    let mint_data = mint.try_borrow()?;
+    let extension = get_extension_data(&mint_data, TRANSFER_HOOK).ok_or(AblError::MintNotUsingThisHook)?;
+    let hook_program = extension.get(32..64).ok_or(AblError::MintNotUsingThisHook)?;
+    if hook_program != program_id.as_ref() {
+        return Err(AblError::MintNotUsingThisHook.into());
+    }
+    drop(mint_data);
+
+    if meta_list.data_len() != EXTRA_ACCOUNT_METAS_DATA.len() {
+        meta_list.resize(EXTRA_ACCOUNT_METAS_DATA.len())?;
+    }
+    top_up_rent(payer, meta_list)?;
+    meta_list.try_borrow_mut()?.copy_from_slice(&EXTRA_ACCOUNT_METAS_DATA);
+
+    log!("Meta list resized");
+    Ok(())
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/mint.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/mint.rs
@@ -244,11 +244,17 @@ pub fn attach_to_mint(program_id: &Address, accounts: &mut [AccountView]) -> Pro
         return Err(AblError::InvalidAccountData.into());
     }
 
+    // Everything `Execute` will later parse has to be readable now: a valid
+    // mode alongside a malformed threshold bricks the mint just as surely as
+    // no metadata at all.
     {
         let mint_data = mint.try_borrow()?;
         let metadata = read_ab_metadata(&mint_data, [MODE_KEY, THRESHOLD_KEY])?;
         let mode = metadata.mode.ok_or(AblError::InvalidMetadata)?;
         Mode::from_metadata_value(&mode)?;
+        if let Some(threshold) = metadata.threshold {
+            decimal_to_u64(&threshold)?;
+        }
     }
 
     log!("Pointing the mint at this hook");

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/mod.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/mod.rs
@@ -1,0 +1,71 @@
+mod config;
+mod mint;
+mod tx_hook;
+
+pub use config::*;
+pub use mint::*;
+pub use tx_hook::*;
+
+use pinocchio::{AccountView, Address};
+
+use crate::error::AblError;
+
+/// The SPL Token-2022 program ID
+/// (`TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`).
+pub const TOKEN_2022_PROGRAM_ID: Address =
+    pinocchio::Address::from_str_const("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+
+/// A serialized `ExtraAccountMetaList` naming the two allow/block records this
+/// hook needs — one for each side of the transfer.
+///
+/// ```text
+///   [105, 37, 101, 197, 75, 251, 102, 26]  Execute discriminator
+///   [74, 0, 0, 0]                          value length (u32) = 4 + 2 * 35
+///   [2, 0, 0, 0]                           account count (u32) = 2
+///   ---- two 35-byte ExtraAccountMetas ----
+///   [1]                                    a PDA of this program
+///   [1, 9, b"ab_wallet", 4, 0, 32, 32, ..] seed config, padded to 32 bytes
+///   [0] [0]                                is_signer, is_writable
+///   [1]
+///   [1, 9, b"ab_wallet", 4, 2, 32, 32, ..]
+///   [0] [0]
+/// ```
+///
+/// Each seed config is `Seed::Literal(b"ab_wallet")` followed by
+/// `Seed::AccountData { account_index, data_index: 32, length: 32 }` — 32 bytes
+/// at offset 32 of a token account is its owner. Account 0 of the `Execute`
+/// call is the source token account and account 2 the destination, so
+/// Token-2022 derives both wallets' records itself and no caller names them.
+#[rustfmt::skip]
+pub const EXTRA_ACCOUNT_METAS_DATA: [u8; 86] = [
+    105, 37, 101, 197, 75, 251, 102, 26,
+    74, 0, 0, 0,
+    2, 0, 0, 0,
+    // source wallet's record
+    1,
+    1, 9, b'a', b'b', b'_', b'w', b'a', b'l', b'l', b'e', b't',
+    4, 0, 32, 32,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,
+    0,
+    // destination wallet's record
+    1,
+    1, 9, b'a', b'b', b'_', b'w', b'a', b'l', b'l', b'e', b't',
+    4, 2, 32, 32,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,
+    0,
+];
+
+/// Confirms `account` is the PDA for `seeds`, returning its bump.
+pub fn expect_pda(
+    program_id: &Address,
+    account: &AccountView,
+    seeds: &[&[u8]],
+) -> Result<u8, pinocchio::error::ProgramError> {
+    let (address, bump) = Address::find_program_address(seeds, program_id);
+    if account.address() != &address {
+        return Err(AblError::InvalidSeeds.into());
+    }
+    Ok(bump)
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/tx_hook.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/instructions/tx_hook.rs
@@ -1,0 +1,154 @@
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+use pinocchio_log::log;
+
+use crate::{
+    decide::{decide, MintMode, WalletMode},
+    error::AblError,
+    instructions::{expect_pda, TOKEN_2022_PROGRAM_ID},
+    metadata::{decimal_to_u64, read_ab_metadata},
+    state::{read_wallet_allowed, Mode, AB_WALLET_SEED, AB_WALLET_SIZE, META_LIST_SEED, MODE_KEY, THRESHOLD_KEY},
+    token2022::{get_extension_data, TRANSFER_HOOK, TRANSFER_HOOK_ACCOUNT},
+};
+
+/// A token account stores its mint in the first 32 bytes, then its owner.
+const TOKEN_ACCOUNT_MINT_RANGE: core::ops::Range<usize> = 0..32;
+const TOKEN_ACCOUNT_OWNER_RANGE: core::ops::Range<usize> = 32..64;
+
+/// The `Execute` instruction of the transfer-hook interface.
+///
+/// Token-2022 CPIs this on every transfer of a mint that names this program.
+/// The two allow/block records are resolved from the list, which derives them
+/// from the owners recorded in the source and destination token accounts — so
+/// neither side can nominate its own record.
+///
+/// Accounts:
+///   0. `[]` source token account
+///   1. `[]` mint
+///   2. `[]` destination token account
+///   3. `[]` transfer authority (the owner, or a delegate)
+///   4. `[]` extra account meta list (PDA `[b"extra-account-metas", mint]`)
+///   5. `[]` source wallet's record (PDA `[b"ab_wallet", source owner]`)
+///   6. `[]` destination wallet's record (PDA `[b"ab_wallet", destination owner]`)
+///
+/// Instruction data: `[amount: u64 (LE)]`
+pub fn tx_hook(program_id: &Address, accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
+    let [source_token, mint, destination_token, _authority, meta_list, source_record, destination_record, ..] =
+        accounts
+    else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    let amount = u64::from_le_bytes(
+        data.get(..8)
+            .ok_or(ProgramError::InvalidInstructionData)?
+            .try_into()
+            .map_err(|_| ProgramError::InvalidInstructionData)?,
+    );
+
+    // Anyone can call `Execute` directly, so none of these accounts are taken
+    // on trust. The Anchor version declares them all `UncheckedAccount` and
+    // validates nothing; every check below is this port's addition.
+    expect_pda(program_id, meta_list, &[META_LIST_SEED, mint.address().as_ref()])?;
+    check_hook_is_self(mint, program_id)?;
+    check_is_transferring(source_token, mint)?;
+
+    let source_owner = token_account_owner(source_token)?;
+    let destination_owner = token_account_owner(destination_token)?;
+    expect_pda(program_id, source_record, &[AB_WALLET_SEED, &source_owner])?;
+    expect_pda(program_id, destination_record, &[AB_WALLET_SEED, &destination_owner])?;
+
+    let mint_mode = read_mint_mode(mint)?;
+    let source_mode = read_wallet_mode(program_id, source_record)?;
+    let destination_mode = read_wallet_mode(program_id, destination_record)?;
+
+    decide(mint_mode, source_mode, destination_mode, amount)?;
+
+    log!("Transfer allowed");
+    Ok(())
+}
+
+fn token_account_owner(token_account: &AccountView) -> Result<[u8; 32], ProgramError> {
+    let data = token_account.try_borrow()?;
+    let bytes = data.get(TOKEN_ACCOUNT_OWNER_RANGE).ok_or(AblError::InvalidSourceAccount)?;
+    let mut owner = [0u8; 32];
+    owner.copy_from_slice(bytes);
+    Ok(owner)
+}
+
+/// A wallet with no record is neither allowed nor blocked.
+fn read_wallet_mode(program_id: &Address, record: &AccountView) -> Result<WalletMode, ProgramError> {
+    if record.is_data_empty() {
+        return Ok(WalletMode::None);
+    }
+    if !record.owned_by(program_id) || record.data_len() != AB_WALLET_SIZE {
+        return Err(AblError::InvalidAccountData.into());
+    }
+
+    if read_wallet_allowed(&record.try_borrow()?)? {
+        Ok(WalletMode::Allow)
+    } else {
+        Ok(WalletMode::Block)
+    }
+}
+
+/// Reads the mode out of the mint's metadata.
+///
+/// A mint whose metadata names a threshold is in mixed mode regardless of what
+/// the `AB` key says, matching the Anchor version's precedence — leaving mixed
+/// mode zeroes the threshold rather than removing the key.
+fn read_mint_mode(mint: &AccountView) -> Result<MintMode, ProgramError> {
+    let mint_data = mint.try_borrow()?;
+    let metadata = read_ab_metadata(&mint_data, [MODE_KEY, THRESHOLD_KEY])?;
+
+    let threshold = match metadata.threshold {
+        Some(value) => decimal_to_u64(&value)?,
+        None => 0,
+    };
+    if threshold > 0 {
+        return Ok(MintMode::Threshold(threshold));
+    }
+
+    match metadata.mode {
+        Some(value) => match Mode::from_metadata_value(&value)? {
+            Mode::Allow => Ok(MintMode::Allow),
+            Mode::Block => Ok(MintMode::Block),
+            Mode::Mixed => Ok(MintMode::Threshold(threshold)),
+        },
+        None => Err(AblError::InvalidMetadata.into()),
+    }
+}
+
+/// Fails unless `mint` names this program as its transfer hook.
+///
+/// A mint hooked to a different program is mid-transfer too while that program
+/// runs, and could otherwise CPI here and be told its transfer is fine.
+fn check_hook_is_self(mint: &AccountView, program_id: &Address) -> ProgramResult {
+    let mint_data = mint.try_borrow()?;
+    let extension = get_extension_data(&mint_data, TRANSFER_HOOK).ok_or(AblError::MintNotUsingThisHook)?;
+    let hook_program = extension.get(32..64).ok_or(AblError::MintNotUsingThisHook)?;
+    if hook_program != program_id.as_ref() {
+        return Err(AblError::MintNotUsingThisHook.into());
+    }
+    Ok(())
+}
+
+/// Fails unless the source account is a genuine Token-2022 account for `mint`
+/// that is mid-transfer.
+fn check_is_transferring(source_token: &AccountView, mint: &AccountView) -> ProgramResult {
+    if !source_token.owned_by(&TOKEN_2022_PROGRAM_ID) {
+        return Err(AblError::InvalidSourceAccount.into());
+    }
+
+    let account_data = source_token.try_borrow()?;
+    let account_mint = account_data.get(TOKEN_ACCOUNT_MINT_RANGE).ok_or(AblError::InvalidSourceAccount)?;
+    if account_mint != mint.address().as_ref() {
+        return Err(AblError::InvalidSourceAccount.into());
+    }
+
+    let extension =
+        get_extension_data(&account_data, TRANSFER_HOOK_ACCOUNT).ok_or(AblError::IsNotCurrentlyTransferring)?;
+    match extension.first() {
+        Some(1) => Ok(()),
+        _ => Err(AblError::IsNotCurrentlyTransferring.into()),
+    }
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/lib.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+
+// The `entrypoint!` macro installs the default (bump) global allocator, so the
+// `alloc` crate is available — used to build Token-2022 and token-metadata
+// instruction data at runtime.
+extern crate alloc;
+
+pub mod decide;
+pub mod error;
+pub mod instructions;
+pub mod metadata;
+pub mod processor;
+pub mod state;
+pub mod token2022;
+pub mod util;
+
+use pinocchio::{entrypoint, nostd_panic_handler};
+
+entrypoint!(processor::process_instruction);
+nostd_panic_handler!();

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/metadata.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/metadata.rs
@@ -1,0 +1,191 @@
+//! Reading and writing the mint's SPL token metadata.
+//!
+//! The mode this hook enforces lives in the mint's own `TokenMetadata`
+//! extension, under the `AB` key, with an optional `threshold`. There is no
+//! pinocchio crate for either Token-2022 or the token-metadata interface, so
+//! the TLV value is parsed and the two instructions are built by hand.
+
+use alloc::vec::Vec;
+
+use pinocchio::{
+    error::ProgramError,
+    instruction::{InstructionAccount, InstructionView},
+    AccountView, Address, ProgramResult,
+};
+
+use crate::{error::AblError, token2022::get_extension_data};
+
+/// `ExtensionType::TokenMetadata`, a variable-length extension.
+pub const TOKEN_METADATA: u16 = 19;
+
+/// `spl_token_metadata_interface` discriminators: the first eight bytes of
+/// `sha256("spl_token_metadata_interface:<name>")`.
+///
+/// Computed from the preimages in the interface crate rather than copied, since
+/// the crate never spells the bytes out.
+const METADATA_INITIALIZE: [u8; 8] = [210, 225, 30, 162, 88, 184, 77, 141];
+const METADATA_UPDATE_FIELD: [u8; 8] = [221, 233, 49, 45, 181, 202, 220, 200];
+
+/// `Field::Key(..)` — the variant for a caller-defined key, as opposed to the
+/// three built-in name/symbol/uri fields.
+const FIELD_KEY: u8 = 3;
+
+/// Borsh-encodes a string: a little-endian u32 length, then the bytes.
+fn push_string(out: &mut Vec<u8>, value: &[u8]) {
+    out.extend_from_slice(&(value.len() as u32).to_le_bytes());
+    out.extend_from_slice(value);
+}
+
+/// Reads a borsh string, returning it and the offset just past it.
+fn read_string(data: &[u8], offset: usize) -> Result<(&[u8], usize), ProgramError> {
+    let len_bytes = data.get(offset..offset + 4).ok_or(AblError::InvalidMetadata)?;
+    let len = u32::from_le_bytes(len_bytes.try_into().unwrap()) as usize;
+    let start = offset + 4;
+    let end = start.checked_add(len).ok_or(AblError::InvalidMetadata)?;
+    let value = data.get(start..end).ok_or(AblError::InvalidMetadata)?;
+    Ok((value, end))
+}
+
+/// The two values this hook cares about, read out of the mint's metadata.
+pub struct AbMetadata {
+    pub mode: Option<Vec<u8>>,
+    pub threshold: Option<Vec<u8>>,
+}
+
+/// Parses `TokenMetadata` out of a mint and returns the `AB` and `threshold`
+/// entries.
+///
+/// The extension's value is
+/// `update_authority(32) | mint(32) | name | symbol | uri | additional[]`,
+/// where every string is borsh-encoded and `additional` is a length-prefixed
+/// list of key/value pairs. Every read is bounds-checked: this parses account
+/// data a caller chose, so malformed input must error rather than panic.
+pub fn read_ab_metadata(mint_data: &[u8], keys: [&[u8]; 2]) -> Result<AbMetadata, ProgramError> {
+    let value = get_extension_data(mint_data, TOKEN_METADATA).ok_or(AblError::InvalidMetadata)?;
+
+    // Skip the update authority and mint.
+    let mut offset = 64usize;
+    for _ in 0..3 {
+        let (_, next) = read_string(value, offset)?;
+        offset = next;
+    }
+
+    let count_bytes = value.get(offset..offset + 4).ok_or(AblError::InvalidMetadata)?;
+    let count = u32::from_le_bytes(count_bytes.try_into().unwrap());
+    offset += 4;
+
+    let mut found: [Option<Vec<u8>>; 2] = [None, None];
+    for _ in 0..count {
+        let (key, next) = read_string(value, offset)?;
+        let (entry, next) = read_string(value, next)?;
+        offset = next;
+
+        for (index, wanted) in keys.iter().enumerate() {
+            if key == *wanted && found[index].is_none() {
+                found[index] = Some(entry.to_vec());
+            }
+        }
+    }
+
+    let [mode, threshold] = found;
+    Ok(AbMetadata { mode, threshold })
+}
+
+/// Builds and invokes `Initialize` on the token-metadata interface.
+///
+/// The metadata lives in the mint itself, so `metadata` and `mint` are the same
+/// account — that is what the `MetadataPointer` extension pointing at the mint
+/// means.
+#[allow(clippy::too_many_arguments)]
+pub fn metadata_initialize(
+    token_program: &Address,
+    metadata: &AccountView,
+    update_authority: &AccountView,
+    mint: &AccountView,
+    mint_authority: &AccountView,
+    name: &[u8],
+    symbol: &[u8],
+    uri: &[u8],
+) -> ProgramResult {
+    let mut data = Vec::with_capacity(8 + 12 + name.len() + symbol.len() + uri.len());
+    data.extend_from_slice(&METADATA_INITIALIZE);
+    push_string(&mut data, name);
+    push_string(&mut data, symbol);
+    push_string(&mut data, uri);
+
+    let accounts = [
+        InstructionAccount::writable(metadata.address()),
+        InstructionAccount::readonly(update_authority.address()),
+        InstructionAccount::readonly(mint.address()),
+        InstructionAccount::readonly_signer(mint_authority.address()),
+    ];
+
+    // One account info per instruction meta — the metadata and the mint are the
+    // same account here, as are the two authorities, but the CPI still expects
+    // the list to line up.
+    pinocchio::cpi::invoke(
+        &InstructionView { program_id: token_program, accounts: &accounts, data: &data },
+        &[*metadata, *update_authority, *mint, *mint_authority],
+    )
+}
+
+/// Builds and invokes `UpdateField` for a caller-defined key.
+pub fn metadata_update_field(
+    token_program: &Address,
+    metadata: &AccountView,
+    update_authority: &AccountView,
+    key: &[u8],
+    value: &[u8],
+) -> ProgramResult {
+    let mut data = Vec::with_capacity(8 + 1 + 8 + key.len() + value.len());
+    data.extend_from_slice(&METADATA_UPDATE_FIELD);
+    data.push(FIELD_KEY);
+    push_string(&mut data, key);
+    push_string(&mut data, value);
+
+    let accounts = [
+        InstructionAccount::writable(metadata.address()),
+        InstructionAccount::readonly_signer(update_authority.address()),
+    ];
+
+    pinocchio::cpi::invoke(
+        &InstructionView { program_id: token_program, accounts: &accounts, data: &data },
+        &[*metadata, *update_authority],
+    )
+}
+
+/// Formats a `u64` into a decimal string without allocating a formatter.
+///
+/// The Anchor version stores the threshold as `u64::to_string()`, so this has
+/// to produce the same bytes for the two implementations to read each other's
+/// mints.
+pub fn u64_to_decimal(mut value: u64) -> Vec<u8> {
+    if value == 0 {
+        return alloc::vec![b'0'];
+    }
+
+    let mut digits = Vec::with_capacity(20);
+    while value > 0 {
+        digits.push(b'0' + (value % 10) as u8);
+        value /= 10;
+    }
+    digits.reverse();
+    digits
+}
+
+/// Parses a decimal string back into a `u64`.
+pub fn decimal_to_u64(bytes: &[u8]) -> Result<u64, ProgramError> {
+    if bytes.is_empty() {
+        return Err(AblError::InvalidMetadata.into());
+    }
+
+    let mut value = 0u64;
+    for byte in bytes {
+        if !byte.is_ascii_digit() {
+            return Err(AblError::InvalidMetadata.into());
+        }
+        value =
+            value.checked_mul(10).and_then(|v| v.checked_add((byte - b'0') as u64)).ok_or(AblError::InvalidMetadata)?;
+    }
+    Ok(value)
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/processor.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/processor.rs
@@ -1,0 +1,68 @@
+use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
+use pinocchio_log::log;
+
+use crate::instructions::{
+    attach_to_mint, change_mode, init_config, init_mint, init_wallet, remove_wallet, resize_meta_list, tx_hook,
+};
+
+/// `spl-transfer-hook-interface:execute`, the first eight bytes of its sha256.
+///
+/// Fixed by the interface: Token-2022 CPIs this program with exactly these
+/// bytes during a transfer.
+const EXECUTE: [u8; 8] = [105, 37, 101, 197, 75, 251, 102, 26];
+
+/// This example's own instructions. Single-byte tags, none of which can shadow
+/// the eight-byte discriminator above, which starts with 105.
+const INIT_CONFIG: u8 = 0;
+const INIT_MINT: u8 = 1;
+const ATTACH_TO_MINT: u8 = 2;
+const INIT_WALLET: u8 = 3;
+const REMOVE_WALLET: u8 = 4;
+const CHANGE_MODE: u8 = 5;
+const RESIZE_META_LIST: u8 = 6;
+
+/// Entrypoint for the program.
+pub fn process_instruction(
+    program_id: &Address,
+    accounts: &mut [AccountView],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    // The interface discriminator is matched first: it is eight bytes, so a
+    // one-byte tag could otherwise shadow it.
+    if let Some(data) = instruction_data.strip_prefix(&EXECUTE) {
+        log!("Instruction: Execute");
+        return tx_hook(program_id, accounts, data);
+    }
+
+    match instruction_data {
+        [INIT_CONFIG, ..] => {
+            log!("Instruction: InitConfig");
+            init_config(program_id, accounts)
+        }
+        [INIT_MINT, data @ ..] => {
+            log!("Instruction: InitMint");
+            init_mint(program_id, accounts, data)
+        }
+        [ATTACH_TO_MINT, ..] => {
+            log!("Instruction: AttachToMint");
+            attach_to_mint(program_id, accounts)
+        }
+        [INIT_WALLET, data @ ..] => {
+            log!("Instruction: InitWallet");
+            init_wallet(program_id, accounts, data)
+        }
+        [REMOVE_WALLET, ..] => {
+            log!("Instruction: RemoveWallet");
+            remove_wallet(program_id, accounts)
+        }
+        [CHANGE_MODE, data @ ..] => {
+            log!("Instruction: ChangeMode");
+            change_mode(program_id, accounts, data)
+        }
+        [RESIZE_META_LIST, ..] => {
+            log!("Instruction: ResizeMetaList");
+            resize_meta_list(program_id, accounts)
+        }
+        _ => Err(ProgramError::InvalidInstructionData),
+    }
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/state.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/state.rs
@@ -1,0 +1,107 @@
+//! Account layouts and seeds.
+//!
+//! Written as plain little-endian bytes. There is no 8-byte Anchor account
+//! discriminator, so both accounts are 8 bytes smaller than their counterparts.
+
+use pinocchio::{error::ProgramError, Address};
+
+use crate::error::AblError;
+
+/// Seed of the program config PDA.
+pub const CONFIG_SEED: &[u8] = b"config";
+
+/// Seed prefix of a wallet's allow/block record.
+pub const AB_WALLET_SEED: &[u8] = b"ab_wallet";
+
+/// Seed prefix of the `ExtraAccountMetaList` PDA, fixed by the transfer-hook
+/// interface.
+pub const META_LIST_SEED: &[u8] = b"extra-account-metas";
+
+/// `authority(32) | bump(1)`
+pub const CONFIG_SIZE: usize = 33;
+
+/// `wallet(32) | allowed(1)`
+pub const AB_WALLET_SIZE: usize = 33;
+
+/// The metadata key holding the mint's allow/block mode.
+pub const MODE_KEY: &[u8] = b"AB";
+
+/// The metadata key holding the mixed-mode threshold.
+pub const THRESHOLD_KEY: &[u8] = b"threshold";
+
+/// How a mint gates transfers.
+///
+/// Stored in the mint's token metadata as a string under `AB`, matching the
+/// Anchor version so the two implementations read each other's mints.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Mode {
+    /// Only wallets explicitly allowed may receive.
+    Allow,
+    /// Anyone may transact except wallets explicitly blocked.
+    Block,
+    /// Like `Block`, but transfers at or above the threshold need an allowed
+    /// receiver.
+    Mixed,
+}
+
+impl Mode {
+    pub fn from_byte(byte: u8) -> Result<Self, ProgramError> {
+        match byte {
+            0 => Ok(Mode::Allow),
+            1 => Ok(Mode::Block),
+            2 => Ok(Mode::Mixed),
+            _ => Err(AblError::InvalidMode.into()),
+        }
+    }
+
+    /// The exact strings the Anchor version writes, via its `Display` impl.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Mode::Allow => "Allow",
+            Mode::Block => "Block",
+            Mode::Mixed => "Mixed",
+        }
+    }
+
+    pub fn from_metadata_value(value: &[u8]) -> Result<Self, ProgramError> {
+        match value {
+            b"Allow" => Ok(Mode::Allow),
+            b"Block" => Ok(Mode::Block),
+            b"Mixed" => Ok(Mode::Mixed),
+            _ => Err(AblError::InvalidMetadata.into()),
+        }
+    }
+}
+
+pub fn read_config_authority(data: &[u8]) -> Result<&[u8], ProgramError> {
+    if data.len() != CONFIG_SIZE {
+        return Err(AblError::InvalidAccountData.into());
+    }
+    Ok(&data[..32])
+}
+
+pub fn write_config(data: &mut [u8], authority: &Address, bump: u8) -> Result<(), ProgramError> {
+    if data.len() != CONFIG_SIZE {
+        return Err(AblError::InvalidAccountData.into());
+    }
+    data[..32].copy_from_slice(authority.as_ref());
+    data[32] = bump;
+    Ok(())
+}
+
+/// Whether a wallet's record says it is allowed.
+pub fn read_wallet_allowed(data: &[u8]) -> Result<bool, ProgramError> {
+    if data.len() != AB_WALLET_SIZE {
+        return Err(AblError::InvalidAccountData.into());
+    }
+    Ok(data[32] != 0)
+}
+
+pub fn write_wallet(data: &mut [u8], wallet: &Address, allowed: bool) -> Result<(), ProgramError> {
+    if data.len() != AB_WALLET_SIZE {
+        return Err(AblError::InvalidAccountData.into());
+    }
+    data[..32].copy_from_slice(wallet.as_ref());
+    data[32] = allowed as u8;
+    Ok(())
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/token2022.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/token2022.rs
@@ -1,0 +1,56 @@
+//! A minimal reader for the Token-2022 TLV extension area.
+//!
+//! There is no pinocchio crate for Token-2022, so rather than pull in
+//! `spl-token-2022` this example walks the extension list by hand. Only the two
+//! extensions it cares about are named below.
+
+/// Offset at which the TLV extension list begins.
+///
+/// Token-2022 lays out any account carrying extensions as its base data padded
+/// to `Account::LEN` (165 bytes), a one-byte account type, then the TLV list.
+/// Mints (82 bytes on their own) are padded up to 165 for exactly this reason,
+/// so the same offset serves both mints and token accounts.
+const TLV_START: usize = 166;
+
+/// Marks a TLV slot that has never been written; the list ends here.
+const UNINITIALIZED: u16 = 0;
+
+/// `ExtensionType::TransferHook` — on a *mint*, names the hook program.
+pub const TRANSFER_HOOK: u16 = 14;
+
+/// `ExtensionType::TransferHookAccount` — on a *token account*, carries the
+/// `transferring` flag Token-2022 raises for the duration of a transfer.
+pub const TRANSFER_HOOK_ACCOUNT: u16 = 15;
+
+/// Returns the value bytes of `extension_type`, or `None` when the account is
+/// too short, holds no extensions, or does not carry this one.
+///
+/// Each entry is a 2-byte type, a 2-byte little-endian length, then that many
+/// value bytes. Every read is bounds-checked: this parses account data that a
+/// caller chose, so malformed input must return `None` rather than panic.
+pub fn get_extension_data(account_data: &[u8], extension_type: u16) -> Option<&[u8]> {
+    let tlv = account_data.get(TLV_START..)?;
+    let mut cursor = 0usize;
+
+    while cursor.checked_add(4)? <= tlv.len() {
+        let entry_type = u16::from_le_bytes([tlv[cursor], tlv[cursor + 1]]);
+        if entry_type == UNINITIALIZED {
+            return None;
+        }
+
+        let length = u16::from_le_bytes([tlv[cursor + 2], tlv[cursor + 3]]) as usize;
+        let value_start = cursor + 4;
+        let value_end = value_start.checked_add(length)?;
+        if value_end > tlv.len() {
+            return None;
+        }
+
+        if entry_type == extension_type {
+            return Some(&tlv[value_start..value_end]);
+        }
+
+        cursor = value_end;
+    }
+
+    None
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/util.rs
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/program/src/util.rs
@@ -1,0 +1,38 @@
+//! Shared account-creation helper.
+
+use pinocchio::{
+    cpi::{Seed, Signer},
+    sysvars::{rent::Rent, Sysvar},
+    AccountView, Address, ProgramResult,
+};
+use pinocchio_system::instructions::{Allocate, Assign, Transfer};
+
+/// Creates `account` at a PDA, tolerating an address that already holds
+/// lamports.
+///
+/// `CreateAccount` fails outright if the target has a balance, and every PDA
+/// here has a publicly derivable address — so anyone could send one lamport to
+/// one of these addresses and permanently block the instruction that was
+/// meant to create it. Topping the account up and then allocating and assigning
+/// it separately sidesteps that; it is the same fallback Anchor's `init`
+/// performs.
+pub fn create_pda_account(
+    payer: &AccountView,
+    account: &mut AccountView,
+    space: usize,
+    owner: &Address,
+    seeds: &[Seed],
+) -> ProgramResult {
+    let required = Rent::get()?.try_minimum_balance(space)?;
+    let current = account.lamports();
+
+    if current < required {
+        Transfer { from: payer, to: account, lamports: required - current }.invoke()?;
+    }
+
+    let signer = [Signer::from(seeds)];
+    Allocate { account, space: space as u64 }.invoke_signed(&signer)?;
+    Assign { account, owner }.invoke_signed(&signer)?;
+
+    Ok(())
+}

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/tests/test.ts
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/tests/test.ts
@@ -1,0 +1,563 @@
+import * as path from 'node:path';
+import {
+    AccountRole,
+    type Address,
+    type KeyPairSigner,
+    appendTransactionMessageInstruction,
+    appendTransactionMessageInstructions,
+    createTransactionMessage,
+    generateKeyPairSigner,
+    getAddressEncoder,
+    getProgramDerivedAddress,
+    lamports,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    signTransactionMessageWithSigners,
+    unwrapOption,
+} from '@solana/kit';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
+import {
+    ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TOKEN_2022_PROGRAM_ADDRESS,
+    findAssociatedTokenPda,
+    getCreateAssociatedTokenInstruction,
+    getMintDecoder,
+    getMintToInstruction,
+    getTokenDecoder,
+    getTransferCheckedInstruction,
+} from '@solana-program/token-2022';
+import { assert } from 'chai';
+import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
+
+const INIT_CONFIG = 0;
+const INIT_MINT = 1;
+const INIT_WALLET = 3;
+const REMOVE_WALLET = 4;
+const CHANGE_MODE = 5;
+const RESIZE_META_LIST = 6;
+
+const MODE_ALLOW = 0;
+const MODE_BLOCK = 1;
+const MODE_MIXED = 2;
+
+// The serialized ExtraAccountMetaList the program writes: the Execute
+// discriminator, a u32 value length of 74 (4 + two 35-byte metas), a count of
+// 2, then one meta per side of the transfer. Each is a PDA of this program
+// seeded by Literal("ab_wallet") and AccountData reading 32 bytes at offset 32
+// of the source (index 0) and destination (index 2) token accounts.
+// prettier-ignore
+const EXPECTED_EXTRA_ACCOUNT_METAS = Uint8Array.from([
+    105, 37, 101, 197, 75, 251, 102, 26,
+    74, 0, 0, 0,
+    2, 0, 0, 0,
+    1,
+    1, 9, 97, 98, 95, 119, 97, 108, 108, 101, 116,
+    4, 0, 32, 32,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,
+    0,
+    1,
+    1, 9, 97, 98, 95, 119, 97, 108, 108, 101, 116,
+    4, 2, 32, 32,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,
+    0,
+]);
+
+const DECIMALS = 2;
+const MINTED = 10_000n;
+const SMALL = 10n;
+const LARGE = 5_000n;
+const THRESHOLD = 1_000n;
+
+const PROGRAM_SO = path.join(process.cwd(), 'tests', 'fixtures', 'token_2022_abl_token_pinocchio_program.so');
+const addressEncoder = getAddressEncoder();
+
+function u64(n: bigint): Uint8Array {
+    const b = new Uint8Array(8);
+    new DataView(b.buffer).setBigUint64(0, n, true);
+    return b;
+}
+function str(value: string): Uint8Array {
+    const bytes = new TextEncoder().encode(value);
+    return concatBytes(Uint8Array.of(bytes.length), bytes);
+}
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+    const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+    let offset = 0;
+    for (const p of parts) {
+        out.set(p, offset);
+        offset += p.length;
+    }
+    return out;
+}
+
+describe('Token-2022 Transfer Hook — Allow/Block List Token (Pinocchio)', () => {
+    let svm: LiteSVM;
+    let programId: Address;
+    let payer: KeyPairSigner;
+    let mint: KeyPairSigner;
+    let config: Address;
+    let metaList: Address;
+    let alice: KeyPairSigner;
+    let bob: KeyPairSigner;
+    let aliceAta: Address;
+    let bobAta: Address;
+
+    before(async () => {
+        svm = new LiteSVM();
+        // The program derives every PDA from the id it is invoked with, so a
+        // generated id keeps the test self-contained.
+        programId = (await generateKeyPairSigner()).address;
+        svm.addProgramFromFile(programId, PROGRAM_SO);
+
+        payer = await generateKeyPairSigner();
+        alice = await generateKeyPairSigner();
+        bob = await generateKeyPairSigner();
+        for (const signer of [payer, alice, bob]) {
+            svm.airdrop(signer.address, lamports(10_000_000_000n));
+        }
+
+        mint = await generateKeyPairSigner();
+
+        [config] = await getProgramDerivedAddress({ programAddress: programId, seeds: ['config'] });
+        [metaList] = await getProgramDerivedAddress({
+            programAddress: programId,
+            seeds: ['extra-account-metas', addressEncoder.encode(mint.address)],
+        });
+        [aliceAta] = await findAssociatedTokenPda({
+            owner: alice.address,
+            mint: mint.address,
+            tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        });
+        [bobAta] = await findAssociatedTokenPda({
+            owner: bob.address,
+            mint: mint.address,
+            tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        });
+    });
+
+    async function tx(
+        instructions: Parameters<typeof appendTransactionMessageInstruction>[0][],
+        feePayer: KeyPairSigner = payer,
+    ) {
+        return signTransactionMessageWithSigners(
+            pipe(
+                createTransactionMessage({ version: 0 }),
+                m => setTransactionMessageFeePayerSigner(feePayer, m),
+                m => svm.setTransactionMessageLifetimeUsingLatestBlockhash(m),
+                m => appendTransactionMessageInstructions(instructions, m),
+            ),
+        );
+    }
+
+    function send(signedTx: Parameters<typeof svm.sendTransaction>[0], label: string) {
+        const result = svm.sendTransaction(signedTx);
+        if (result instanceof FailedTransactionMetadata) {
+            throw new Error(`${label} failed: ${result.err()}`);
+        }
+        return result;
+    }
+
+    function tokenAmount(account: Address): bigint {
+        const acc = svm.getAccount(account);
+        if (!acc?.exists) throw new Error('token account not found');
+        return getTokenDecoder().decode(acc.data).amount;
+    }
+
+    async function abWallet(wallet: Address): Promise<Address> {
+        const [address] = await getProgramDerivedAddress({
+            programAddress: programId,
+            seeds: ['ab_wallet', addressEncoder.encode(wallet)],
+        });
+        return address;
+    }
+
+    async function listWalletIx(wallet: Address, allowed: boolean) {
+        return {
+            programAddress: programId,
+            accounts: [
+                { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
+                { address: config, role: AccountRole.READONLY },
+                { address: wallet, role: AccountRole.READONLY },
+                { address: await abWallet(wallet), role: AccountRole.WRITABLE },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+            data: Uint8Array.of(INIT_WALLET, allowed ? 1 : 0),
+        };
+    }
+
+    function changeModeIx(mode: number, threshold: bigint) {
+        return {
+            programAddress: programId,
+            accounts: [
+                { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
+                { address: mint.address, role: AccountRole.WRITABLE },
+                { address: TOKEN_2022_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+            data: concatBytes(Uint8Array.of(CHANGE_MODE, mode), u64(threshold)),
+        };
+    }
+
+    // Token-2022 resolves both records from the list, but the transfer
+    // instruction must still carry them, plus the hook program and the list.
+    async function transferIx(from: KeyPairSigner, fromAta: Address, toAta: Address, toOwner: Address, amount: bigint) {
+        const base = getTransferCheckedInstruction(
+            {
+                source: fromAta,
+                mint: mint.address,
+                destination: toAta,
+                authority: from,
+                amount,
+                decimals: DECIMALS,
+            },
+            { programAddress: TOKEN_2022_PROGRAM_ADDRESS },
+        );
+        return {
+            ...base,
+            accounts: [
+                ...base.accounts,
+                { address: await abWallet(from.address), role: AccountRole.READONLY },
+                { address: await abWallet(toOwner), role: AccountRole.READONLY },
+                { address: programId, role: AccountRole.READONLY },
+                { address: metaList, role: AccountRole.READONLY },
+            ],
+        };
+    }
+
+    function expectFailure(result: unknown, code: string, label: string) {
+        assert.instanceOf(result, FailedTransactionMetadata, `expected ${label} to be rejected`);
+        assert.include(
+            (result as FailedTransactionMetadata).meta().logs().join('\n'),
+            `custom program error: ${code}`,
+            label,
+        );
+    }
+
+    it('Creates the config', async () => {
+        const ix = {
+            programAddress: programId,
+            accounts: [
+                { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
+                { address: config, role: AccountRole.WRITABLE },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+            data: Uint8Array.of(INIT_CONFIG),
+        };
+        send(await tx([ix]), 'init config');
+
+        const account = svm.getAccount(config);
+        if (!account?.exists) throw new Error('config not found');
+        assert.equal(account.programAddress, programId, 'the config is owned by the program');
+        assert.deepEqual(
+            Array.from(account.data.slice(0, 32)),
+            Array.from(addressEncoder.encode(payer.address)),
+            'the authority was recorded',
+        );
+    });
+
+    it('Creates a mint gated by this hook, in Allow mode', async () => {
+        const ix = {
+            programAddress: programId,
+            accounts: [
+                { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
+                { address: mint.address, role: AccountRole.WRITABLE_SIGNER, signer: mint },
+                { address: metaList, role: AccountRole.WRITABLE },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+                { address: TOKEN_2022_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+            data: concatBytes(
+                Uint8Array.of(INIT_MINT, DECIMALS, MODE_ALLOW),
+                u64(0n),
+                new Uint8Array(addressEncoder.encode(payer.address)), // permanent delegate
+                new Uint8Array(addressEncoder.encode(payer.address)), // transfer hook authority
+                str('ABL Token'),
+                str('ABL'),
+                str('https://example.com/abl.json'),
+            ),
+        };
+        send(await tx([ix]), 'init mint');
+
+        const account = svm.getAccount(mint.address);
+        if (!account?.exists) throw new Error('mint not found');
+        const state = getMintDecoder().decode(account.data);
+        assert.equal(state.decimals, DECIMALS);
+
+        const extensions = unwrapOption(state.extensions) ?? [];
+        const hook = extensions.find(e => e.__kind === 'TransferHook');
+        if (hook?.__kind !== 'TransferHook') throw new Error('TransferHook extension missing');
+        assert.equal(hook.programId, programId, 'the mint points at this program');
+
+        assert.isDefined(
+            extensions.find(e => e.__kind === 'PermanentDelegate'),
+            'permanent delegate set',
+        );
+        assert.isDefined(
+            extensions.find(e => e.__kind === 'MetadataPointer'),
+            'metadata pointer set',
+        );
+
+        const metadata = extensions.find(e => e.__kind === 'TokenMetadata');
+        if (metadata?.__kind !== 'TokenMetadata') throw new Error('TokenMetadata extension missing');
+        assert.equal(metadata.name, 'ABL Token');
+        assert.equal(metadata.symbol, 'ABL');
+        assert.deepEqual(
+            metadata.additionalMetadata.get('AB'),
+            'Allow',
+            'the mode was written where the Anchor version reads it',
+        );
+
+        const list = svm.getAccount(metaList);
+        if (!list?.exists) throw new Error('meta list not found');
+        assert.deepEqual(
+            Array.from(list.data),
+            Array.from(EXPECTED_EXTRA_ACCOUNT_METAS),
+            'the list resolves both wallets from the token accounts',
+        );
+    });
+
+    it('Creates token accounts and mints supply', async () => {
+        send(
+            await tx([
+                getCreateAssociatedTokenInstruction({
+                    payer,
+                    ata: aliceAta,
+                    owner: alice.address,
+                    mint: mint.address,
+                    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+                }),
+                getCreateAssociatedTokenInstruction({
+                    payer,
+                    ata: bobAta,
+                    owner: bob.address,
+                    mint: mint.address,
+                    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+                }),
+                getMintToInstruction(
+                    { mint: mint.address, token: aliceAta, mintAuthority: payer, amount: MINTED },
+                    { programAddress: TOKEN_2022_PROGRAM_ADDRESS },
+                ),
+            ]),
+            'create token accounts',
+        );
+
+        assert.equal(tokenAmount(aliceAta), MINTED);
+    });
+
+    it('Allow mode blocks a transfer to an unlisted wallet', async () => {
+        const result = svm.sendTransaction(
+            await tx([await transferIx(alice, aliceAta, bobAta, bob.address, SMALL)], alice),
+        );
+        expectFailure(result, '0x1', 'rejected with WalletNotAllowed');
+        assert.equal(tokenAmount(bobAta), 0n, 'nothing moved');
+    });
+
+    it('Allow mode permits a transfer once the receiver is listed', async () => {
+        send(await tx([await listWalletIx(bob.address, true)]), 'allow bob');
+        svm.expireBlockhash();
+
+        send(await tx([await transferIx(alice, aliceAta, bobAta, bob.address, SMALL)], alice), 'transfer to bob');
+        assert.equal(tokenAmount(bobAta), SMALL, 'bob was paid');
+    });
+
+    it('A blocked sender cannot transfer even to an allowed receiver', async () => {
+        // The Anchor version checks both sides; the sender check is the one
+        // that is easy to omit, so it gets its own case.
+        send(await tx([await listWalletIx(alice.address, false)]), 'block alice');
+        svm.expireBlockhash();
+
+        const before = tokenAmount(bobAta);
+        const result = svm.sendTransaction(
+            await tx([await transferIx(alice, aliceAta, bobAta, bob.address, SMALL)], alice),
+        );
+        expectFailure(result, '0x0', 'rejected with WalletBlocked');
+        assert.equal(tokenAmount(bobAta), before, 'nothing moved');
+    });
+
+    it('Delisting a wallet restores it to the default treatment', async () => {
+        const record = await abWallet(alice.address);
+        const ix = {
+            programAddress: programId,
+            accounts: [
+                { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
+                { address: config, role: AccountRole.READONLY },
+                { address: alice.address, role: AccountRole.READONLY },
+                { address: record, role: AccountRole.WRITABLE },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+            data: Uint8Array.of(REMOVE_WALLET),
+        };
+        send(await tx([ix]), 'delist alice');
+
+        assert.isNotTrue(svm.getAccount(record)?.exists, 'the record is gone');
+
+        svm.expireBlockhash();
+        send(await tx([await transferIx(alice, aliceAta, bobAta, bob.address, SMALL)], alice), 'transfer after delist');
+    });
+
+    it('Rejects listing a wallet from a non-authority', async () => {
+        const impostor = alice;
+        const ix = {
+            ...(await listWalletIx(bob.address, false)),
+            accounts: [
+                { address: impostor.address, role: AccountRole.WRITABLE_SIGNER, signer: impostor },
+                { address: config, role: AccountRole.READONLY },
+                { address: bob.address, role: AccountRole.READONLY },
+                { address: await abWallet(bob.address), role: AccountRole.WRITABLE },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+        };
+
+        const result = svm.sendTransaction(await tx([ix], impostor));
+        expectFailure(result, '0x8', 'rejected with NotAuthority');
+    });
+
+    it('Block mode lets unlisted wallets transact', async () => {
+        send(await tx([changeModeIx(MODE_BLOCK, 0n)]), 'switch to block mode');
+
+        const carol = await generateKeyPairSigner();
+        svm.airdrop(carol.address, lamports(1_000_000_000n));
+        const [carolAta] = await findAssociatedTokenPda({
+            owner: carol.address,
+            mint: mint.address,
+            tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        });
+        send(
+            await tx([
+                getCreateAssociatedTokenInstruction({
+                    payer,
+                    ata: carolAta,
+                    owner: carol.address,
+                    mint: mint.address,
+                    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+                }),
+            ]),
+            "create carol's account",
+        );
+
+        send(
+            await tx([await transferIx(alice, aliceAta, carolAta, carol.address, SMALL)], alice),
+            'transfer to an unlisted wallet',
+        );
+        assert.equal(tokenAmount(carolAta), SMALL, 'carol was paid without being listed');
+    });
+
+    it('Mixed mode gates only transfers at or above the threshold', async () => {
+        send(await tx([changeModeIx(MODE_MIXED, THRESHOLD)]), 'switch to mixed mode');
+
+        const dave = await generateKeyPairSigner();
+        const [daveAta] = await findAssociatedTokenPda({
+            owner: dave.address,
+            mint: mint.address,
+            tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        });
+        send(
+            await tx([
+                getCreateAssociatedTokenInstruction({
+                    payer,
+                    ata: daveAta,
+                    owner: dave.address,
+                    mint: mint.address,
+                    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+                }),
+            ]),
+            "create dave's account",
+        );
+
+        // Below the threshold an unlisted receiver is fine.
+        send(await tx([await transferIx(alice, aliceAta, daveAta, dave.address, SMALL)], alice), 'small transfer');
+        assert.equal(tokenAmount(daveAta), SMALL, 'the small transfer went through');
+
+        // At or above it, the receiver must be listed.
+        svm.expireBlockhash();
+        const result = svm.sendTransaction(
+            await tx([await transferIx(alice, aliceAta, daveAta, dave.address, LARGE)], alice),
+        );
+        expectFailure(result, '0x2', 'rejected with AmountNotAllowed');
+
+        // Listing dave lets the large transfer through.
+        send(await tx([await listWalletIx(dave.address, true)]), 'allow dave');
+        svm.expireBlockhash();
+        send(await tx([await transferIx(alice, aliceAta, daveAta, dave.address, LARGE)], alice), 'large transfer');
+        assert.equal(tokenAmount(daveAta), SMALL + LARGE, 'the large transfer went through');
+    });
+
+    it('Rewrites the meta list permissionlessly', async () => {
+        // Deliberately open: the content is fully determined by the mint and
+        // this program's fixed list, so a mint whose hook authority was revoked
+        // is not stranded. Anyone may call it.
+        const stranger = await generateKeyPairSigner();
+        svm.airdrop(stranger.address, lamports(1_000_000_000n));
+
+        const ix = {
+            programAddress: programId,
+            accounts: [
+                { address: stranger.address, role: AccountRole.WRITABLE_SIGNER, signer: stranger },
+                { address: mint.address, role: AccountRole.READONLY },
+                { address: metaList, role: AccountRole.WRITABLE },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+            data: Uint8Array.of(RESIZE_META_LIST),
+        };
+        send(await tx([ix], stranger), 'resize meta list');
+
+        const list = svm.getAccount(metaList);
+        if (!list?.exists) throw new Error('meta list not found');
+        assert.deepEqual(Array.from(list.data), Array.from(EXPECTED_EXTRA_ACCOUNT_METAS), 'the list is unchanged');
+    });
+
+    it('Rejects rewriting the list for a mint that does not use this hook', async () => {
+        const otherMint = await generateKeyPairSigner();
+        const [otherList] = await getProgramDerivedAddress({
+            programAddress: programId,
+            seeds: ['extra-account-metas', addressEncoder.encode(otherMint.address)],
+        });
+
+        // A mint with no TransferHook extension at all.
+        svm.setAccount({
+            address: otherMint.address,
+            data: new Uint8Array(82),
+            executable: false,
+            lamports: lamports(svm.minimumBalanceForRentExemption(82n)),
+            programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+            space: 82n,
+        });
+
+        const ix = {
+            programAddress: programId,
+            accounts: [
+                { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
+                { address: otherMint.address, role: AccountRole.READONLY },
+                { address: otherList, role: AccountRole.WRITABLE },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+            data: Uint8Array.of(RESIZE_META_LIST),
+        };
+
+        const result = svm.sendTransaction(await tx([ix]));
+        expectFailure(result, '0x5', 'rejected with MintNotUsingThisHook');
+    });
+
+    it('Rejects calling the hook outside a transfer', async () => {
+        // Anchor declares every account here unchecked and validates nothing.
+        // This port refuses a direct call, so the decision can only be reached
+        // through a real transfer.
+        const ix = {
+            programAddress: programId,
+            accounts: [
+                { address: aliceAta, role: AccountRole.READONLY },
+                { address: mint.address, role: AccountRole.READONLY },
+                { address: bobAta, role: AccountRole.READONLY },
+                { address: alice.address, role: AccountRole.READONLY },
+                { address: metaList, role: AccountRole.READONLY },
+                { address: await abWallet(alice.address), role: AccountRole.READONLY },
+                { address: await abWallet(bob.address), role: AccountRole.READONLY },
+            ],
+            data: concatBytes(Uint8Array.from([105, 37, 101, 197, 75, 251, 102, 26]), u64(SMALL)),
+        };
+
+        const result = svm.sendTransaction(await tx([ix]));
+        expectFailure(result, '0xa', 'rejected with IsNotCurrentlyTransferring');
+    });
+});

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/tests/test.ts
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/tests/test.ts
@@ -15,7 +15,7 @@ import {
     signTransactionMessageWithSigners,
     unwrapOption,
 } from '@solana/kit';
-import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
+import { SYSTEM_PROGRAM_ADDRESS, getTransferSolInstruction } from '@solana-program/system';
 import {
     ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
     TOKEN_2022_PROGRAM_ADDRESS,
@@ -574,6 +574,94 @@ describe('Token-2022 Transfer Hook — Allow/Block List Token (Pinocchio)', () =
         const result = svm.sendTransaction(await tx([ix]));
         expectFailure(result, '0x3', 'rejected with InvalidMetadata');
         assert.isNotTrue(svm.getAccount(bareList)?.exists, 'no meta list was created');
+    });
+
+    it('Refuses to attach to a mint whose threshold is malformed', async () => {
+        // A valid mode alongside an unparseable threshold bricks the mint just
+        // as surely as no metadata at all, since `Execute` parses both. The
+        // guard has to cover everything the hook will later read.
+        const second = await generateKeyPairSigner();
+        const [secondList] = await getProgramDerivedAddress({
+            programAddress: programId,
+            seeds: ['extra-account-metas', addressEncoder.encode(second.address)],
+        });
+
+        const initSecondIx = {
+            programAddress: programId,
+            accounts: [
+                { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
+                { address: second.address, role: AccountRole.WRITABLE_SIGNER, signer: second },
+                { address: secondList, role: AccountRole.WRITABLE },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+                { address: TOKEN_2022_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+            data: concatBytes(
+                Uint8Array.of(INIT_MINT, DECIMALS, MODE_ALLOW),
+                u64(0n),
+                new Uint8Array(addressEncoder.encode(payer.address)),
+                new Uint8Array(addressEncoder.encode(payer.address)),
+                str('Second'),
+                str('SEC'),
+                str('https://example.com/second.json'),
+            ),
+        };
+        send(await tx([initSecondIx]), 'init second mint');
+
+        // Clear the list so `attach_to_mint` has something to create, then put
+        // a non-decimal threshold on the mint via a raw UpdateField.
+        svm.setAccount({
+            address: secondList,
+            data: new Uint8Array(0),
+            executable: false,
+            lamports: lamports(0n),
+            programAddress: SYSTEM_PROGRAM_ADDRESS,
+            space: 0n,
+        });
+
+        const borshString = (value: string) => {
+            const bytes = new TextEncoder().encode(value);
+            const len = new Uint8Array(4);
+            new DataView(len.buffer).setUint32(0, bytes.length, true);
+            return concatBytes(len, bytes);
+        };
+        const badThresholdIx = {
+            programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+            accounts: [
+                { address: second.address, role: AccountRole.WRITABLE },
+                { address: payer.address, role: AccountRole.READONLY_SIGNER, signer: payer },
+            ],
+            data: concatBytes(
+                Uint8Array.from([221, 233, 49, 45, 181, 202, 220, 200]), // UpdateField
+                Uint8Array.of(3), // Field::Key
+                borshString('threshold'),
+                borshString('not-a-number'),
+            ),
+        };
+        // The extra key grows the mint, so top its rent up in the same
+        // transaction or the write drops it below exemption.
+        send(
+            await tx([
+                getTransferSolInstruction({ source: payer, destination: second.address, amount: lamports(5_000_000n) }),
+                badThresholdIx,
+            ]),
+            'write a malformed threshold',
+        );
+
+        const ix = {
+            programAddress: programId,
+            accounts: [
+                { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
+                { address: second.address, role: AccountRole.WRITABLE },
+                { address: secondList, role: AccountRole.WRITABLE },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+                { address: TOKEN_2022_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+            data: Uint8Array.of(ATTACH_TO_MINT),
+        };
+
+        const result = svm.sendTransaction(await tx([ix]));
+        expectFailure(result, '0x3', 'rejected with InvalidMetadata');
+        assert.isNotTrue(svm.getAccount(secondList)?.exists, 'no meta list was created');
     });
 
     it('Rejects calling the hook outside a transfer', async () => {

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/tests/test.ts
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/tests/test.ts
@@ -31,6 +31,7 @@ import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
 
 const INIT_CONFIG = 0;
 const INIT_MINT = 1;
+const ATTACH_TO_MINT = 2;
 const INIT_WALLET = 3;
 const REMOVE_WALLET = 4;
 const CHANGE_MODE = 5;
@@ -537,6 +538,42 @@ describe('Token-2022 Transfer Hook — Allow/Block List Token (Pinocchio)', () =
 
         const result = svm.sendTransaction(await tx([ix]));
         expectFailure(result, '0x5', 'rejected with MintNotUsingThisHook');
+    });
+
+    it('Refuses to attach to a mint carrying no policy', async () => {
+        // Attaching would switch the hook on over metadata `Execute` cannot
+        // read, and `ChangeMode` can only update metadata that already exists —
+        // so a mint with no `TokenMetadata` would be stuck with every transfer
+        // failing and no way back. Refusing here makes that unreachable.
+        const bareMint = await generateKeyPairSigner();
+        const [bareList] = await getProgramDerivedAddress({
+            programAddress: programId,
+            seeds: ['extra-account-metas', addressEncoder.encode(bareMint.address)],
+        });
+        svm.setAccount({
+            address: bareMint.address,
+            data: new Uint8Array(82),
+            executable: false,
+            lamports: lamports(svm.minimumBalanceForRentExemption(82n)),
+            programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+            space: 82n,
+        });
+
+        const ix = {
+            programAddress: programId,
+            accounts: [
+                { address: payer.address, role: AccountRole.WRITABLE_SIGNER, signer: payer },
+                { address: bareMint.address, role: AccountRole.WRITABLE },
+                { address: bareList, role: AccountRole.WRITABLE },
+                { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+                { address: TOKEN_2022_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+            ],
+            data: Uint8Array.of(ATTACH_TO_MINT),
+        };
+
+        const result = svm.sendTransaction(await tx([ix]));
+        expectFailure(result, '0x3', 'rejected with InvalidMetadata');
+        assert.isNotTrue(svm.getAccount(bareList)?.exists, 'no meta list was created');
     });
 
     it('Rejects calling the hook outside a transfer', async () => {

--- a/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/tsconfig.json
+++ b/tokens/token-2022/transfer-hook/allow-block-list-token/pinocchio/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "types": ["mocha", "chai", "node"],
+        "typeRoots": ["./node_modules/@types"],
+        "lib": ["esnext"],
+        "module": "esnext",
+        "target": "esnext",
+        "moduleResolution": "bundler",
+        "esModuleInterop": true,
+        "resolveJsonModule": true,
+        "allowImportingTsExtensions": true,
+        "noEmit": true,
+        "skipLibCheck": true
+    }
+}


### PR DESCRIPTION
Adds a Pinocchio implementation of `allow-block-list-token`, alongside the existing Anchor one. This is the last of the six transfer-hook variants.

### What it does

A transfer hook enforcing an allow/block list, with the policy stored in the mint's own token metadata so it travels with the token:

- **Allow** — only wallets explicitly on the list may receive.
- **Block** — anyone may transact except wallets explicitly blocked.
- **Mixed** — like Block, but transfers at or above a threshold need an allowed receiver.

Eight instructions: `InitConfig`, `InitMint`, `AttachToMint`, `InitWallet`, `RemoveWallet`, `ChangeMode`, `ResizeMetaList`, and the interface's `Execute`.

### Reading the mode out of the mint

The mode lives in the mint's `TokenMetadata` extension under an `AB` key, with an optional `threshold` — exactly where the Anchor version puts it, so both implementations read each other's mints. There is no Pinocchio crate for Token-2022 *or* the token-metadata interface, so `metadata.rs` parses the variable-length TLV by hand (`update_authority | mint | name | symbol | uri | additional[]`, all borsh strings, every read bounds-checked) and builds the two interface instructions itself.

Their discriminators are the first eight bytes of `sha256("spl_token_metadata_interface:initialize_account")` and `…:updating_field`. I computed those from the preimages rather than copying them from anywhere, and cross-checked the method against `spl-transfer-hook-interface:execute`, which reproduced the value already shipping in the sibling hook examples.

`init_mint` also builds a mint carrying three extensions — `PermanentDelegate`, `TransferHook` and `MetadataPointer` — which have to be initialized *before* `InitializeMint2`, since Token-2022 refuses extension setup afterwards.

### The decision logic

`decide()` is a pure function of the decoded mint mode, both wallet states and the amount, so it is unit-testable without building accounts. It carries 8 `#[cfg(test)]` tests, mirroring the Anchor version's — including the one guarding that a **blocked sender** is rejected in every mint mode, which is the side that is easy to omit.

### Validation this port adds

The Anchor `TxHook` struct declares every account `UncheckedAccount` and validates nothing. That is defensible there — the hook only reads and returns a verdict — but it means a direct call is answered on whatever accounts the caller supplies. This port refuses one: the metas list must be the mint's PDA, the mint's `TransferHook` extension must name this program, the source must be a Token-2022 account for that mint and mid-transfer, and both wallet records must be the PDAs derived from the owners recorded in the source and destination token accounts.

That last one matters most: the records are what the verdict is read from, so if a caller could nominate them the answer would be theirs to choose.

### Differences from the Anchor version

- No 8-byte account discriminators, so `Config` and each `ABWallet` are 33 bytes.
- `Mode` travels as a `u8` in instruction data and as the same string as Anchor's `Display` in metadata.
- `RemoveWallet` moves the rent to the authority *before* closing — pinocchio's `close()` zeroes the lamports field outright, so closing first destroys them and unbalances the instruction.
- `ResizeMetaList` is permissionless, as in the reference: the content is fully determined by the mint and this program's fixed list, so gating it would strand mints whose hook authority was revoked.

### Tests

13 LiteSVM tests covering all three modes end to end (including the blocked-sender case and the mixed-mode threshold on both sides), plus non-authority, wrong-mint and direct-call rejections — and 8 unit tests on `decide()`. Verified locally: `cargo test`, `tsc --noEmit`, `pnpm test`, `prettier --check`, `cargo fmt --check`, `cargo clippy -D warnings`.
