### PR TITLE
chore: dump fixtures without rewriting the global Solana config

### DIFF
--- a/tokens/create-token/anchor/prepare.mjs
+++ b/tokens/create-token/anchor/prepare.mjs
@@ -18,12 +18,12 @@ try {
     for (const program of programs) {
         const { id, name } = program;
         const outputFile = join(outputDir, name);
-        await $`solana config set -um`;
-
         try {
             await mkdir(outputDir, { recursive: true });
             if (overwrite) await rm(outputFile, { force: true });
-            await $`solana program dump ${id} ${outputFile}`;
+            // `-um` targets mainnet for this command only, leaving the developer's
+            // global Solana CLI config alone.
+            await $`solana program dump -um ${id} ${outputFile}`;
             console.log(`Program ${id} dumped to ${outputFile}`);
         } catch (error) {
             console.error(`Error dumping ${id}: ${error.message}`);

--- a/tokens/create-token/native/prepare.mjs
+++ b/tokens/create-token/native/prepare.mjs
@@ -18,12 +18,12 @@ try {
     for (const program of programs) {
         const { id, name } = program;
         const outputFile = join(outputDir, name);
-        await $`solana config set -um`;
-
         try {
             await mkdir(outputDir, { recursive: true });
             if (overwrite) await rm(outputFile, { force: true });
-            await $`solana program dump ${id} ${outputFile}`;
+            // `-um` targets mainnet for this command only, leaving the developer's
+            // global Solana CLI config alone.
+            await $`solana program dump -um ${id} ${outputFile}`;
             console.log(`Program ${id} dumped to ${outputFile}`);
         } catch (error) {
             console.error(`Error dumping ${id}: ${error.message}`);

--- a/tokens/nft-operations/anchor/prepare.mjs
+++ b/tokens/nft-operations/anchor/prepare.mjs
@@ -18,12 +18,12 @@ try {
     for (const program of programs) {
         const { id, name } = program;
         const outputFile = join(outputDir, name);
-        await $`solana config set -um`;
-
         try {
             await mkdir(outputDir, { recursive: true });
             if (overwrite) await rm(outputFile, { force: true });
-            await $`solana program dump ${id} ${outputFile}`;
+            // `-um` targets mainnet for this command only, leaving the developer's
+            // global Solana CLI config alone.
+            await $`solana program dump -um ${id} ${outputFile}`;
             console.log(`Program ${id} dumped to ${outputFile}`);
         } catch (error) {
             console.error(`Error dumping ${id}: ${error.message}`);

--- a/tokens/nft-operations/pinocchio/prepare.mjs
+++ b/tokens/nft-operations/pinocchio/prepare.mjs
@@ -21,13 +21,13 @@ const outputDir = 'tests/fixtures';
 
 try {
     mkdirSync(outputDir, { recursive: true });
-    // Point the Solana CLI at mainnet, where the canonical program lives.
-    execSync('solana config set -um', { stdio: 'inherit' });
 
     for (const { id, name } of programs) {
         const outputFile = join(outputDir, name);
         rmSync(outputFile, { force: true });
-        execSync(`solana program dump ${id} ${outputFile}`, { stdio: 'inherit' });
+        // `-um` points this one command at mainnet, where the canonical program
+        // lives, without touching the developer's global Solana CLI config.
+        execSync(`solana program dump -um ${id} ${outputFile}`, { stdio: 'inherit' });
         console.log(`Dumped ${id} -> ${outputFile}`);
     }
 } catch (error) {

--- a/tokens/pda-mint-authority/anchor/prepare.mjs
+++ b/tokens/pda-mint-authority/anchor/prepare.mjs
@@ -18,12 +18,12 @@ try {
     for (const program of programs) {
         const { id, name } = program;
         const outputFile = join(outputDir, name);
-        await $`solana config set -um`;
-
         try {
             await mkdir(outputDir, { recursive: true });
             if (overwrite) await rm(outputFile, { force: true });
-            await $`solana program dump ${id} ${outputFile}`;
+            // `-um` targets mainnet for this command only, leaving the developer's
+            // global Solana CLI config alone.
+            await $`solana program dump -um ${id} ${outputFile}`;
             console.log(`Program ${id} dumped to ${outputFile}`);
         } catch (error) {
             console.error(`Error dumping ${id}: ${error.message}`);

--- a/tokens/pda-mint-authority/native/prepare.mjs
+++ b/tokens/pda-mint-authority/native/prepare.mjs
@@ -18,12 +18,12 @@ try {
     for (const program of programs) {
         const { id, name } = program;
         const outputFile = join(outputDir, name);
-        await $`solana config set -um`;
-
         try {
             await mkdir(outputDir, { recursive: true });
             if (overwrite) await rm(outputFile, { force: true });
-            await $`solana program dump ${id} ${outputFile}`;
+            // `-um` targets mainnet for this command only, leaving the developer's
+            // global Solana CLI config alone.
+            await $`solana program dump -um ${id} ${outputFile}`;
             console.log(`Program ${id} dumped to ${outputFile}`);
         } catch (error) {
             console.error(`Error dumping ${id}: ${error.message}`);

--- a/tokens/transfer-tokens/anchor/prepare.mjs
+++ b/tokens/transfer-tokens/anchor/prepare.mjs
@@ -18,12 +18,12 @@ try {
     for (const program of programs) {
         const { id, name } = program;
         const outputFile = join(outputDir, name);
-        await $`solana config set -um`;
-
         try {
             await mkdir(outputDir, { recursive: true });
             if (overwrite) await rm(outputFile, { force: true });
-            await $`solana program dump ${id} ${outputFile}`;
+            // `-um` targets mainnet for this command only, leaving the developer's
+            // global Solana CLI config alone.
+            await $`solana program dump -um ${id} ${outputFile}`;
             console.log(`Program ${id} dumped to ${outputFile}`);
         } catch (error) {
             console.error(`Error dumping ${id}: ${error.message}`);

--- a/tokens/transfer-tokens/native/prepare.mjs
+++ b/tokens/transfer-tokens/native/prepare.mjs
@@ -18,12 +18,12 @@ try {
     for (const program of programs) {
         const { id, name } = program;
         const outputFile = join(outputDir, name);
-        await $`solana config set -um`;
-
         try {
             await mkdir(outputDir, { recursive: true });
             if (overwrite) await rm(outputFile, { force: true });
-            await $`solana program dump ${id} ${outputFile}`;
+            // `-um` targets mainnet for this command only, leaving the developer's
+            // global Solana CLI config alone.
+            await $`solana program dump -um ${id} ${outputFile}`;
             console.log(`Program ${id} dumped to ${outputFile}`);
         } catch (error) {
             console.error(`Error dumping ${id}: ${error.message}`);


### PR DESCRIPTION
Repo-wide follow-up to a review finding on #719, in the same spirit as #702.

## The problem

Every `prepare.mjs` that pulls a program fixture from mainnet ran this first:

```js
await $`solana config set -um`;
```

That is not a per-command flag — it writes mainnet into `~/.config/solana/cli/config.yml` and leaves it there. So `pnpm install` in any of these examples silently repoints the developer's CLI at mainnet, and since the `deploy` scripts here take no cluster flag, a later `pnpm deploy` follows it.

## The fix

Drop the global mutation and pass `-um` to the dump itself, so the cluster is scoped to the one command that needs it:

```js
await $`solana program dump -um ${id} ${outputFile}`;
```

8 files, two script styles (zx in seven, Node stdlib in `nft-operations/pinocchio`). No behavioural change to what gets downloaded.

The `deploy` scripts keep taking no cluster flag on purpose — they should deploy wherever the developer has pointed their CLI. That is only correct once `prepare.mjs` stops moving the target underneath them.

## Verification

Ran both script styles in a container with the global config deliberately set to devnet:

- `tokens/create-token/anchor` (zx, via `pnpm install`) → `token_metadata.so` downloaded, 793,991 bytes
- `tokens/nft-operations/pinocchio` (stdlib, via `node prepare.mjs`) → same fixture, same size
- `solana config get` still reported devnet after both

`prettier --check` passes on all 8 files.
