### PR TITLE
ci: pin unpinned GitHub Actions refs to commit SHAs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -82,7 +82,7 @@ runs:
 
     - name: Setup Node.js
       if: inputs.install-pnpm == 'true' && inputs.node-version-file == ''
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version: ${{ inputs.node-version }}
         check-latest: true
@@ -91,7 +91,7 @@ runs:
 
     - name: Setup Node.js (version file)
       if: inputs.install-pnpm == 'true' && inputs.node-version-file != ''
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: ${{ inputs.node-version-file }}
         check-latest: true
@@ -152,7 +152,7 @@ runs:
     - name: Cache Solana environment
       if: inputs.install-solana == 'true'
       id: cache-solana
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cache/solana/
@@ -201,7 +201,7 @@ runs:
     - name: Cache Anchor and Cargo binaries
       if: inputs.install-anchor == 'true'
       id: cache-anchor
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cargo/bin/avm
@@ -284,7 +284,7 @@ runs:
     - name: Cache sbpf assembler
       if: inputs.install-sbpf == 'true'
       id: cache-sbpf
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cargo/bin/sbpf
         key: ${{ runner.os }}-sbpf-${{ inputs.sbpf-rev }}

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -42,7 +42,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       projects_per_job: ${{ steps.matrix.outputs.projects_per_job }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         if: github.event_name == 'pull_request'
@@ -122,7 +122,7 @@ jobs:
     outputs:
       failed_projects: ${{ steps.set-failed.outputs.failed_projects }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Solana 3.1.8 matches the [toolchain] solana_version every anchor
       # example pins in Anchor.toml. Installing anything else makes anchor
       # build fetch 3.1.8 through agave-install at build time, which fails
@@ -244,7 +244,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create job summary
         run: |
           echo "## Anchor Workflow Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/just.yml
+++ b/.github/workflows/just.yml
@@ -40,7 +40,7 @@ jobs:
       projects: ${{ steps.find.outputs.projects }}
       any: ${{ steps.find.outputs.any }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Discover justfile examples
@@ -94,7 +94,7 @@ jobs:
         project: ${{ fromJson(needs.discover.outputs.projects) }}
     name: ${{ matrix.project }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
         with:
           node-version-file: ${{ matrix.project }}/.nvmrc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check every crate is covered by the root workspace
         run: |
           ignore_pattern=$(grep -v '^#' .github/.workspace-ignore | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable

--- a/.github/workflows/solana-asm.yml
+++ b/.github/workflows/solana-asm.yml
@@ -40,7 +40,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       projects_per_job: ${{ steps.matrix.outputs.projects_per_job }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         if: github.event_name == 'pull_request'
@@ -121,7 +121,7 @@ jobs:
     outputs:
       failed_projects: ${{ steps.set-failed.outputs.failed_projects }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Solana pinned to 4.0.3, the last version the ASM examples passed on
       # (paired with the sbpf rev pinned in the setup action). Floating
       # "stable" moved to 4.1.1 in the same window the toolchain broke. The
@@ -265,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create job summary
         run: |
           echo "## ASM Workflow Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/solana-native.yml
+++ b/.github/workflows/solana-native.yml
@@ -42,7 +42,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       projects_per_job: ${{ steps.matrix.outputs.projects_per_job }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         if: github.event_name == 'pull_request'
@@ -123,7 +123,7 @@ jobs:
     outputs:
       failed_projects: ${{ steps.set-failed.outputs.failed_projects }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
       - name: Setup build environment
         id: setup
@@ -268,7 +268,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create job summary
         run: |
           echo "## Native Workflow Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/solana-pinocchio.yml
+++ b/.github/workflows/solana-pinocchio.yml
@@ -42,7 +42,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       projects_per_job: ${{ steps.matrix.outputs.projects_per_job }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         if: github.event_name == 'pull_request'
@@ -123,7 +123,7 @@ jobs:
     outputs:
       failed_projects: ${{ steps.set-failed.outputs.failed_projects }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
       - name: Setup build environment
         id: setup
@@ -268,7 +268,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create job summary
         run: |
           echo "## Pinocchio Workflow Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           # PRs only — issues are often long-lived example requests.
           days-before-issue-stale: -1

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
## Summary
- Pin all 25 remaining mutable GitHub Actions refs in `.github/` to full 40-hex commit SHAs.
- Supply-chain rationale: tags and branches are mutable, so an upstream tag can be repointed at new code that then runs with our workflow permissions and secrets. A SHA pin is immutable and cannot be changed under us.
- Each pin keeps a trailing ` # <version>` comment, matching the convention already used elsewhere in this repo: it preserves readability at a glance and lets dependabot recognize and bump the pins.
- Files changed: `.github/actions/setup/action.yml`, `.github/workflows/{anchor,just,rust,solana-asm,solana-native,solana-pinocchio,stale,typescript}.yml`.

Breakdown of the 25 refs: `actions/checkout@v7` (18), `actions/cache@v4` (3), `actions/setup-node@v5` (2), `actions/setup-node@v4` (1), `actions/stale@v9` (1).

Note: `actions/setup-node` is used at two different majors (`v4` in `workflows/typescript.yml`, `v5` in the composite action). Each was pinned to the SHA for its own major; versions were deliberately not unified.

Local `./.github/actions/setup` composite refs and refs already pinned to a SHA were left untouched.

## Test Plan
- `grep -rn 'uses:' .github/` excluding `./` and `docker://` refs returns zero refs that are not a 40-hex SHA.
- `git diff` touches only `uses:` lines; no reformatting or reordering.
- CI on this PR exercises the pinned actions.