### PR TITLE
test(basics/checking-accounts): assert the owner constraint rejects a foreign account

### DIFF
--- a/basics/checking-accounts/anchor/tests/litesvm.test.ts
+++ b/basics/checking-accounts/anchor/tests/litesvm.test.ts
@@ -1,9 +1,21 @@
 import * as anchor from '@anchor-lang/core';
 import { Keypair, PublicKey, SystemProgram, Transaction } from '@solana/web3.js';
+import { assert } from 'chai';
 import { LiteSVMProvider } from 'anchor-litesvm';
 import { LiteSVM } from 'litesvm';
 import IDL from '../target/idl/checking_account_program.json' with { type: 'json' };
 import type { CheckingAccountProgram } from '../target/types/checking_account_program.ts';
+
+const expectAnchorError = async (promise: Promise<unknown>, code: string) => {
+    let caught: any;
+    try {
+        await promise;
+    } catch (error) {
+        caught = error;
+    }
+    assert.isDefined(caught, `expected the transaction to fail with ${code}`);
+    assert.strictEqual(caught?.error?.errorCode?.code, code, `expected ${code}, got: ${caught}`);
+};
 
 const PROGRAM_ID = new PublicKey(IDL.address);
 
@@ -47,5 +59,21 @@ describe('LiteSVM example', () => {
                 accountToChange: accountToChange.publicKey,
             })
             .rpc();
+    });
+
+    it('Rejects an account our program does not own', async () => {
+        // accountToCreate was never created, so the runtime presents it as
+        // owned by the System Program — exactly what `owner = id()` must refuse.
+        await expectAnchorError(
+            program.methods
+                .checkAccounts()
+                .accounts({
+                    payer: wallet.publicKey,
+                    accountToCreate: accountToCreate.publicKey,
+                    accountToChange: accountToCreate.publicKey,
+                })
+                .rpc(),
+            'ConstraintOwner',
+        );
     });
 });

--- a/basics/checking-accounts/anchor/tests/test.ts
+++ b/basics/checking-accounts/anchor/tests/test.ts
@@ -1,6 +1,18 @@
 import * as anchor from '@anchor-lang/core';
 import { Keypair, SystemProgram, sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
+import { assert } from 'chai';
 import type { CheckingAccountProgram } from '../target/types/checking_account_program.ts';
+
+const expectAnchorError = async (promise: Promise<unknown>, code: string) => {
+    let caught: any;
+    try {
+        await promise;
+    } catch (error) {
+        caught = error;
+    }
+    assert.isDefined(caught, `expected the transaction to fail with ${code}`);
+    assert.strictEqual(caught?.error?.errorCode?.code, code, `expected ${code}, got: ${caught}`);
+};
 
 describe('Anchor example', () => {
     const provider = anchor.AnchorProvider.env();
@@ -37,5 +49,21 @@ describe('Anchor example', () => {
                 accountToChange: accountToChange.publicKey,
             })
             .rpc();
+    });
+
+    it('Rejects an account our program does not own', async () => {
+        // accountToCreate was never created, so the runtime presents it as
+        // owned by the System Program — exactly what `owner = id()` must refuse.
+        await expectAnchorError(
+            program.methods
+                .checkAccounts()
+                .accounts({
+                    payer: wallet.publicKey,
+                    accountToCreate: accountToCreate.publicKey,
+                    accountToChange: accountToCreate.publicKey,
+                })
+                .rpc(),
+            'ConstraintOwner',
+        );
     });
 });


### PR DESCRIPTION
## Summary

`basics/checking-accounts` exists to teach the `owner = id()` constraint on `account_to_change`, but neither suite ever hands the program an account it does not own. Both specs pass a correctly-owned account, and since the handler body is `Ok(())`, the suite would stay green against a program that checks nothing.

This adds one negative spec to each suite (validator and LiteSVM): call `check_accounts` with a System-Program-owned account as `account_to_change` and assert the transaction is rejected with `ConstraintOwner`. The account used is `accountToCreate`, which the suite already declares and never creates, so no extra setup is needed.

The error assertion reuses the inline `expectAnchorError` helper already used by `tokens/pda-mint-authority` and `tokens/token-fundraiser`. No new dependencies; lockfile unchanged.

## Test plan

- `anchor test` at this commit: all specs pass in both suites (6 passing).
- Red proof: with `owner = id()` removed from `CheckingAccounts` and the program rebuilt, the new spec fails in both suites with `expected the transaction to fail with ConstraintOwner`; every other spec still passes (2 failing, 4 passing). Constraint restored, back to green.
- `pnpm check` (prettier) clean.

## AI use

I identified the missing check while reading this example, decided the shape of the test, and reviewed the diff and both test runs; Claude drafted the code and this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
