### PR TITLE
docs(pda-rent-payer): caution note on the unrestricted caller of create_new_account

### DIFF
--- a/basics/pda-rent-payer/anchor/programs/anchor-program-example/src/instructions/create_new_account.rs
+++ b/basics/pda-rent-payer/anchor/programs/anchor-program-example/src/instructions/create_new_account.rs
@@ -1,6 +1,11 @@
 use anchor_lang::prelude::*;
 use anchor_lang::system_program::{create_account, CreateAccount};
 
+// NOTE: this example does not restrict who may call it. A real rent vault
+// needs an authority check: a `has_one` against an admin recorded at
+// initialization, seeds that bind the vault to one funder, or a per-caller
+// limit. A bare `authority: Signer` alone is not enough, since any keypair
+// can sign for itself.
 #[derive(Accounts)]
 pub struct CreateNewAccount<'info> {
     #[account(mut)]

--- a/basics/pda-rent-payer/native/program/src/instructions/create_new_account.rs
+++ b/basics/pda-rent-payer/native/program/src/instructions/create_new_account.rs
@@ -8,6 +8,10 @@ use solana_program::{
 
 use crate::state::RentVault;
 
+// NOTE: this example does not restrict who may call it. A real rent vault
+// needs an authority check: an authority recorded at initialization with
+// seeds that bind the vault to one funder, or a per-caller limit. A bare
+// signer alone is not enough, since any keypair can sign for itself.
 pub fn create_new_account(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let new_account = next_account_info(accounts_iter)?;

--- a/basics/pda-rent-payer/pinocchio/program/src/instructions/create_new_account.rs
+++ b/basics/pda-rent-payer/pinocchio/program/src/instructions/create_new_account.rs
@@ -6,6 +6,10 @@ use pinocchio::{
 
 use crate::state::RentVault;
 
+// NOTE: this example does not restrict who may call it. A real rent vault
+// needs an authority check: an authority recorded at initialization with
+// seeds that bind the vault to one funder, or a per-caller limit. A bare
+// signer alone is not enough, since any keypair can sign for itself.
 pub fn create_new_account(
     program_id: &Address,
     accounts: &mut [AccountView],


### PR DESCRIPTION
## What and why

`create_new_account` spends from a shared `rent_vault` PDA and the only signer is the newly created account itself, so anyone can drain the vault one rent-exempt minimum at a time. That is intentional here - the example exists to show a PDA signing for itself - but it is exactly the kind of helper that gets copied into real programs, per the discussion in #671.

This adds the suggested caution comment above the instruction in all three flavors (anchor, native, pinocchio) so the note travels with whatever version a reader copies. No behavior changes; the example keeps teaching what it teaches.

Fixes #671

## AI disclosure

Check exactly one. See [CONTRIBUTING.md](https://github.com/solana-foundation/program-examples/blob/main/CONTRIBUTING.md#ai-use).

- [ ] No AI tooling was used beyond editor autocomplete.
- [x] AI tooling was used. Tool and extent: drafted the comment text with Claude; I reviewed the diff across the three flavors and matched each file's style before opening.

## Testing

Comment-only change, no code touched.
